### PR TITLE
ci: enable publish to pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      # - name: Publish distribution 📦 to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     # currently not working with reusable workflows
-      #     attestations: false
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # currently not working with reusable workflows
+          attestations: false


### PR DESCRIPTION
Enable publishing to pypi as `docling-mcp` package
