### PR TITLE
Uri file path to local document cache

### DIFF
--- a/docling_mcp/tools/conversion.py
+++ b/docling_mcp/tools/conversion.py
@@ -10,17 +10,16 @@ from docling.datamodel.pipeline_options import (
 )
 from docling.document_converter import DocumentConverter, FormatOption, PdfFormatOption
 from docling.utils.accelerator_utils import AcceleratorDevice
-from docling_core.types.doc import DoclingDocument
-from docling_core.types.doc.labels import (
-    DocItemLabel,
-)
 from docling_core.types.doc.document import (
     ContentLayer,
 )
+from docling_core.types.doc.labels import (
+    DocItemLabel,
+)
 
-from docling_mcp.docling_cache import get_cache_dir, get_cache_key
+from docling_mcp.docling_cache import get_cache_key
 from docling_mcp.logger import setup_logger
-from docling_mcp.shared import local_document_cache, mcp, local_stack_cache
+from docling_mcp.shared import local_document_cache, local_stack_cache, mcp
 
 # Create a default project logger
 logger = setup_logger()
@@ -79,7 +78,6 @@ def convert_pdf_document_into_json_docling_document_from_uri_path(
         if cache_key in local_document_cache:
             logger.info(f"{source} has previously been added.")
             return False, "Document already exists in the system cache."
-
 
         # Log the start of processing
         logger.info("Set up pipeline options")

--- a/docling_mcp/tools/conversion.py
+++ b/docling_mcp/tools/conversion.py
@@ -51,7 +51,7 @@ def convert_pdf_document_into_json_docling_document_from_uri_path(
     source: str,
 ) -> tuple[bool, str]:
     """
-    Convert a PDF document from a URL or local path to Docling document and then store in local cache.
+    Convert a PDF document from a URL or local path and store in local cache.
 
     Args:
         source: URL or local file path to the document

--- a/docling_mcp/tools/conversion.py
+++ b/docling_mcp/tools/conversion.py
@@ -11,10 +11,16 @@ from docling.datamodel.pipeline_options import (
 from docling.document_converter import DocumentConverter, FormatOption, PdfFormatOption
 from docling.utils.accelerator_utils import AcceleratorDevice
 from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.labels import (
+    DocItemLabel,
+)
+from docling_core.types.doc.document import (
+    ContentLayer,
+)
 
 from docling_mcp.docling_cache import get_cache_dir, get_cache_key
 from docling_mcp.logger import setup_logger
-from docling_mcp.shared import local_document_cache, mcp
+from docling_mcp.shared import local_document_cache, mcp, local_stack_cache
 
 # Create a default project logger
 logger = setup_logger()
@@ -44,17 +50,17 @@ def is_document_in_local_cache(cache_key: str) -> bool:
 @mcp.tool()
 def convert_pdf_document_into_json_docling_document_from_uri_path(
     source: str,
-) -> tuple[bool, dict]:
+) -> tuple[bool, str]:
     """
-    Convert a PDF document from a URL or local path to markdown format.
+    Convert a PDF document from a URL or local path to Docling document and then store in local cache.
 
     Args:
         source: URL or local file path to the document
 
     Returns:
         The tools returns a tuple, the first element being a boolean
-        representing success and the second  for The document content
-        in JSON format or an error message.
+        representing success and the second for the cache_key to allow
+        future access to the file.
 
     Usage:
         convert_document("https://arxiv.org/pdf/2408.09869")
@@ -69,12 +75,11 @@ def convert_pdf_document_into_json_docling_document_from_uri_path(
 
         # Generate cache key
         cache_key = get_cache_key(source)
-        cache_file = get_cache_dir() / f"{cache_key}.json"
 
-        # Check if result is cached
-        if cache_file.exists():
-            logger.info(f"Using cached result for {source}")
-            return (True, DoclingDocument.load_from_json(cache_file).export_to_dict())
+        if cache_key in local_document_cache:
+            logger.info(f"{source} has previously been added.")
+            return False, "Document already exists in the system cache."
+
 
         # Log the start of processing
         logger.info("Set up pipeline options")
@@ -117,19 +122,23 @@ def convert_pdf_document_into_json_docling_document_from_uri_path(
             error_msg = f"Conversion failed: {error_message}"
             raise McpError(ErrorData(code=INTERNAL_ERROR, message=error_msg))
 
-        # Export to markdown
-        logger.info("Exporting to JSON")
+        local_document_cache[cache_key] = result.document
 
-        result.document.save_as_json(filename=cache_file)
-        doc = result.document.export_to_dict()
+        item = result.document.add_text(
+            label=DocItemLabel.TEXT,
+            text=f"source: {source}",
+            content_layer=ContentLayer.FURNITURE,
+        )
+
+        local_stack_cache[cache_key] = [item]
 
         # Log completion
-        logger.info(f"Successfully converted document: {source}")
+        logger.info(f"Successfully created the Docling document: {source}")
 
         # Clean up memory
         cleanup_memory()
 
-        return (True, doc)
+        return True, cache_key
 
     except Exception as e:
         logger.exception(f"Error converting document: {source}")

--- a/docling_mcp/tools/generation.py
+++ b/docling_mcp/tools/generation.py
@@ -92,6 +92,38 @@ def export_docling_document_to_markdown(document_key: str) -> str:
 
 
 @mcp.tool()
+def export_docling_document_to_json(document_key: str) -> str:
+    """
+    Exports a document from the local document cache to JSON format.
+
+    This tool converts a Docling document that exists in the local cache into
+    a json formatted string, which can be used for display or further processing.
+
+    Args:
+        document_key (str): The unique identifier for the document in the local cache.
+
+    Returns:
+        str: A string containing the JSON representation of the document,
+             along with a header identifying the document key.
+
+    Raises:
+        ValueError: If the specified document_key does not exist in the local cache.
+
+    Example:
+        export_docling_document_to_json("doc123")
+    """
+    if document_key not in local_document_cache:
+        doc_keys = ", ".join(local_document_cache.keys())
+        raise ValueError(
+            f"document-key: {document_key} is not found. Existing document-keys are: {doc_keys}"
+        )
+
+    document: dict = local_document_cache[document_key].export_to_dict()
+
+    return f"JSON export for document with key: {document_key}\n\n{document}\n\n"
+
+
+@mcp.tool()
 def save_docling_document(document_key: str) -> str:
     """
     Saves a document from the local document cache to disk in both markdown and JSON formats.

--- a/docling_mcp/tools/generation.py
+++ b/docling_mcp/tools/generation.py
@@ -106,38 +106,6 @@ def export_docling_document_to_markdown(document_key: str) -> str:
 
 
 @mcp.tool()
-def export_docling_document_to_json(document_key: str) -> str:
-    """
-    Exports a document from the local document cache to JSON format.
-
-    This tool converts a Docling document that exists in the local cache into
-    a json formatted string, which can be used for display or further processing.
-
-    Args:
-        document_key (str): The unique identifier for the document in the local cache.
-
-    Returns:
-        str: A string containing the JSON representation of the document,
-             along with a header identifying the document key.
-
-    Raises:
-        ValueError: If the specified document_key does not exist in the local cache.
-
-    Example:
-        export_docling_document_to_json("doc123")
-    """
-    if document_key not in local_document_cache:
-        doc_keys = ", ".join(local_document_cache.keys())
-        raise ValueError(
-            f"document-key: {document_key} is not found. Existing document-keys are: {doc_keys}"
-        )
-
-    document: dict = local_document_cache[document_key].export_to_dict()
-
-    return f"JSON export for document with key: {document_key}\n\n{document}\n\n"
-
-
-@mcp.tool()
 def save_docling_document(document_key: str) -> str:
     """
     Saves a document from the local document cache to disk in both markdown and JSON formats.


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->


  1. Add a description of the changes (frequently the same as the commit description)

Changing the convert_pdf_document_into_json_docling_document_from_uri_path tool to convert PDF to Docling document and store to local memory cache.

Then I have added the JSON export tool which takes a document cache_id, finds the document in the local memory cache and returns the dict of the document.





**Issue resolved by this Pull Request:**
Resolves # https://github.com/docling-project/docling-mcp/issues/7
