### PR TITLE
ci: add missing code coverage config file

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  # https://docs.codecov.io/docs/comparing-commits
+  allow_coverage_offsets: true
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        target: auto  # auto compares coverage to the previous base commit
+        if_ci_failed: success
+        flags:
+          - docling_mcp
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  branches:               # branch names that can post comment
+    - "main"


### PR DESCRIPTION
The `codecov.yml` file defines the options for ci/cd messages when comparing commits.