### PR TITLE
fix: Expose manipulation tools in mcp_server

### DIFF
--- a/docling_mcp/servers/mcp_server.py
+++ b/docling_mcp/servers/mcp_server.py
@@ -23,6 +23,13 @@ from docling_mcp.tools.generation import (
     save_docling_document,
 )
 
+from docling_mcp.tools.manipulation import (
+    get_overview_of_document_anchors,
+    get_text_of_document_item_at_anchor,
+    update_text_of_document_item_at_anchor,
+    delete_document_items_at_anchors
+)
+
 if (
     os.getenv("RAG_ENABLED") == "true"
     and os.getenv("OLLAMA_MODEL") != ""


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

The four tools recently added for document manipulation in ```manipulation.py``` were not imported in ```mcp_server.py```. This made the tools inaccessible to MCP clients like Claude. I added the imports in this commit, assuming their omission was unintentional, but please let me know if there is a reason they weren't included!