### PR TITLE
docs: add programmatic examples with Llama Stack

### DIFF
--- a/examples/llama-stack/.env.example
+++ b/examples/llama-stack/.env.example
@@ -1,0 +1,13 @@
+# Llama Stack server (here using a local deployment)
+BASE_URL= "http://localhost:8321"
+
+# Generative AI
+INFERENCE_MODEL="meta-llama/Llama-3.2-3B-Instruct"
+TEMPERATURE="0.0"
+TOP_P="0.95"
+MAX_TOKENS="4096"
+STREAM="False"
+USE_PROMPT_CHAINING= "True"
+
+# MCP-related
+DOCLING_MCP_URL= "http://host.containers.internal:8000/sse"

--- a/examples/llama-stack/README.md
+++ b/examples/llama-stack/README.md
@@ -217,6 +217,8 @@ Instruct the agent to generate a `DoclingDocument` from a given topic and add st
 </table>
 
 
-### Test the agent programmatically 🚧
+### Test the agent programmatically
 
-The same results are achieved when calling the Llama Stack agents runtime from a script.
+The notebook [Agents & Docling MCP with Llama Stack](./agents_and_docling_mcp.ipynb) presents an example of
+using the [Llama Stack Client Python API library](https://github.com/meta-llama/llama-stack-client-python)
+to create agents leveraging Docling MCP tools.

--- a/examples/llama-stack/agents_and_docling_mcp.ipynb
+++ b/examples/llama-stack/agents_and_docling_mcp.ipynb
@@ -1,0 +1,1140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "77893d0a",
+   "metadata": {},
+   "source": [
+    "# Agents & Docling MCP with Llama Stack\n",
+    "\n",
+    "This notebook highlights some use cases for agents that want to leverage **Docling MCP** tools to complete tasks in document understanding.\n",
+    "\n",
+    "We will use the Llama Stack framework. To get an introduction to Llama Stack capabilities, including its current builtin tools, you can refer to the\n",
+    "[Llama Stack Demos on OpenDataHub](https://github.com/opendatahub-io/llama-stack-demos) repository.\n",
+    "\n",
+    "### Agent Example:\n",
+    "\n",
+    "This notebook is a simple example to build a system that can convert PDF files (or any other document format supported by Docling) and ran basic transformation operations on the converted format `DoclingDocument`\n",
+    "\n",
+    "### Docling MCP Tools:\n",
+    "\n",
+    "We will use the tools from the [Docling MCP] server that allow executing tasks such as:\n",
+    "- converting a PDF file from a local or remote location into a unified document representation [DoclingDocument](https://docling-project.github.io/docling/concepts/docling_document/).\n",
+    "- exporting the `DoclingDocument` to a text format (markdown).\n",
+    "- adding new content to a `DoclingDocument`.\n",
+    "- saving a `DoclingDocument` to a file in markdown format."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30845564",
+   "metadata": {},
+   "source": [
+    "## Pre-Requisites\n",
+    "\n",
+    "Before starting this notebook, ensure that you have:\n",
+    "- Followed the instructions in the [README.md](./README.md) file to set up the following resources:\n",
+    "  - Inference model with Ollama\n",
+    "  - Llama Stack server with the Ollama template [distribution-llama](https://hub.docker.com/r/llamastack/distribution-ollama)\n",
+    "  - Docling MCP server \n",
+    "\n",
+    "You may want to create a virtual environment to run this notebook. The [requirements.txt](./requirements.txt) file contains the minimal requirements.\n",
+    "\n",
+    "```bash\n",
+    "python -m venv venv\n",
+    "source venv/bin/activate\n",
+    "pip install --upgrade pip -r requirements.txt\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c88519a5",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Setting Up this Notebook\n",
+    "\n",
+    "Rename or copy the [`.env.example`](./.env.examples) file to create a new file called `.env`. Most environmental variables are already set up with default values to run this notebook and they are aligned to the set up of the pre-requisites, like the Llama Stack server and the Docling MCP endpoints.\n",
+    "\n",
+    "```bash\n",
+    "cp .env.example .env\n",
+    "```\n",
+    "\n",
+    "### Environment variables required for this notebook\n",
+    "\n",
+    "- `BASE_URL`: the URL of the remote Llama Stack server. Defaults to `http://localhost:8321`.\n",
+    "- `INFERENCE_MODEL`: the generative AI model id. Defaults to the Meta Llama 3.2 model (`meta-llama/Llama-3.2-3B-Instruct`).\n",
+    "- `TEMPERATURE` (optional): the temperature to use during inference. Defaults to 0.0.\n",
+    "- `TOP_P` (optional): the top_p parameter to use during inference. Defaults to 0.95.\n",
+    "- `MAX_TOKENS` (optional): the maximum number of tokens that can be generated in the completion. Defaults to 4096.\n",
+    "- `STREAM` (optional): set this to True to stream the output of the model/agent and False otherwise. Defaults to True.\n",
+    "- `USE_PROMPT_CHAINING`: dictates if the prompt should be formatted as a few separate prompts to isolate each step or in a single turn.\n",
+    "- `DOCLING_MCP_URL`: the URL for the Docling MCP server. If the client does not find the tool registered to the llama-stack instance, it will use this URL to register it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9ad7d58",
+   "metadata": {},
+   "source": [
+    "## Necessary Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "07424c55",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "base_url=AnyHttpUrl('http://localhost:8321/') inference_model='meta-llama/Llama-3.2-3B-Instruct' max_tokens=4096 temperature=0.0 top_p=0.95 stream=False use_prompt_chaining=True docling_mcp_url=AnyHttpUrl('http://host.containers.internal:8000/sse')\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "import uuid\n",
+    "\n",
+    "from llama_stack_client import Agent\n",
+    "from llama_stack_client import LlamaStackClient\n",
+    "from llama_stack_client.lib.agents.event_logger import EventLogger\n",
+    "from llama_stack_client.lib.agents.react.agent import ReActAgent\n",
+    "from llama_stack_client.lib.agents.react.tool_parser import ReActOutput\n",
+    "from pydantic import NonNegativeFloat, AnyHttpUrl\n",
+    "from pydantic_settings import BaseSettings, SettingsConfigDict\n",
+    "\n",
+    "from src.utils import step_printer, user_printer\n",
+    "\n",
+    "# set the logger\n",
+    "logger = logging.getLogger(__name__)\n",
+    "if not logger.hasHandlers():\n",
+    "    logger.setLevel(logging.INFO)\n",
+    "    stream_handler = logging.StreamHandler()\n",
+    "    stream_handler.setLevel(logging.INFO)\n",
+    "    formatter = logging.Formatter(\"%(message)s\")\n",
+    "    stream_handler.setFormatter(formatter)\n",
+    "    logger.addHandler(stream_handler)\n",
+    "\n",
+    "\n",
+    "# access the environment variables\n",
+    "class Settings(BaseSettings):\n",
+    "    base_url: AnyHttpUrl\n",
+    "    inference_model: str\n",
+    "    max_tokens: int\n",
+    "    temperature: NonNegativeFloat\n",
+    "    top_p: float\n",
+    "    stream: bool\n",
+    "    use_prompt_chaining: bool\n",
+    "    docling_mcp_url: AnyHttpUrl\n",
+    "\n",
+    "    model_config = SettingsConfigDict(env_file=\".env\", env_file_encoding=\"utf-8\")\n",
+    "\n",
+    "\n",
+    "settings = Settings(\n",
+    "    base_url=\"http://localhost:8321\",\n",
+    "    inference_model=\"meta-llama/Llama-3.2-3B-Instruct\",\n",
+    "    temperature=0.0,\n",
+    "    max_tokens=4096,\n",
+    "    top_p=0.95,\n",
+    "    stream=False,\n",
+    "    use_prompt_chaining=True,\n",
+    "    docling_mcp_url=\"http://host.containers.internal:8000/sse\",\n",
+    ")\n",
+    "print(settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ad79b36",
+   "metadata": {},
+   "source": [
+    "## Setting Up the Server Connection\n",
+    "\n",
+    "Establish the connection to your Llama Stack server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f698f34c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to Llama Stack server @ http://localhost:8321/\n"
+     ]
+    }
+   ],
+   "source": [
+    "client = LlamaStackClient(base_url=str(settings.base_url))\n",
+    "print(f\"Connected to Llama Stack server @ {client.base_url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed93b8e9",
+   "metadata": {},
+   "source": [
+    "## Initializing the Inference Parameters\n",
+    "\n",
+    "Fetch the inference-related parameters from the corresponding environment variables and convert them to the format Llama Stack expects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a2dee538",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference Parameters:\n",
+      "\tSampling Parameters: {'strategy': {'type': 'greedy'}, 'max_tokens': 4096}\n",
+      "\tstream: False\n"
+     ]
+    }
+   ],
+   "source": [
+    "if settings.temperature > 0.0:\n",
+    "    strategy = {\n",
+    "        \"type\": \"top_p\",\n",
+    "        \"temperature\": settings.temperature,\n",
+    "        \"top_p\": settings.top_p,\n",
+    "    }\n",
+    "else:\n",
+    "    strategy = {\"type\": \"greedy\"}\n",
+    "\n",
+    "# sampling_params will later be used to pass the parameters to Llama Stack Agents/Inference APIs\n",
+    "sampling_params = {\n",
+    "    \"strategy\": strategy,\n",
+    "    \"max_tokens\": settings.max_tokens,\n",
+    "}\n",
+    "\n",
+    "print(\n",
+    "    f\"Inference Parameters:\\n\\tSampling Parameters: {sampling_params}\\n\\tstream: {settings.stream}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6eba1f1",
+   "metadata": {},
+   "source": [
+    "## Validate that the Docling MCP tools are available in the Llama Stack instance\n",
+    "\n",
+    "When an instance of Llama Stack is redeployed, it may be the case that the tools will need to be re-registered. Also if a tool is already registered with a Llama Stack instance, trying to register another one with the same `toolgroup_id` will throw you an error.\n",
+    "\n",
+    "For this reason, it is recommended to validate your tools and toolgroups. The following code will check that `mcp::docling` tools are correctly registered, and if not it will attempt to register them using their specific endpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2fa74729",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: GET http://localhost:8321/v1/tools \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: GET http://localhost:8321/v1/tools \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your Llama Stack server is registered with the following tool groups @ {'builtin::wolfram_alpha', 'builtin::rag', 'mcp::docling', 'builtin::websearch'} \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "registered_tools = client.tools.list()\n",
+    "registered_toolgroups = [t.toolgroup_id for t in registered_tools]\n",
+    "if \"mcp::docling\" not in registered_toolgroups:\n",
+    "    client.toolgroups.register(\n",
+    "        toolgroup_id=\"mcp::docling\",\n",
+    "        provider_id=\"model-context-protocol\",\n",
+    "        mcp_endpoint={\"uri\": str(settings.docling_mcp_url)},\n",
+    "    )\n",
+    "\n",
+    "registered_tools = client.tools.list()\n",
+    "registered_toolgroups = [t.toolgroup_id for t in registered_tools]\n",
+    "print(\n",
+    "    f\"Your Llama Stack server is registered with the following tool groups @ {set(registered_toolgroups)} \\n\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bab507be",
+   "metadata": {},
+   "source": [
+    "## Defining our Agent - Prompt Chaining"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5aec5c8c",
+   "metadata": {},
+   "source": [
+    "We define an agent provided with the **Docling MCP** tools. The agent should be able to accomplish the following tasks in a multi-step, multi-tool approach:\n",
+    "\n",
+    "1. Converting a PDF file into the `DoclingDocument` format.\n",
+    "2. Exporting the result in a text format, such as markdown.\n",
+    "3. Generating a summary of the document content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b3a8e40d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_prompt = \"\"\"You are a helpful assistant. You have access to a number of tools.\n",
+    "Whenever a tool is called, be sure to return the Response in a friendly and helpful tone.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "39e0e316",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: GET http://localhost:8321/v1/tools?toolgroup_id=mcp%3A%3Adocling \"HTTP/1.1 200 OK\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create simple agent with tools\n",
+    "agent = Agent(\n",
+    "    client=client,\n",
+    "    model=settings.inference_model,  # replace this with model_id to get the value of INFERENCE_MODEL_ID environment variable\n",
+    "    instructions=model_prompt,  # update system prompt based on the model you are using\n",
+    "    tools=[\"mcp::docling\"],\n",
+    "    tool_config={\"tool_choice\": \"auto\"},\n",
+    "    sampling_params=sampling_params,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a69aab5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/bf6de0a0-3fcc-46c6-bc9b-3a33ce32f1e2/session \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/bf6de0a0-3fcc-46c6-bc9b-3a33ce32f1e2/session/a9546fef-6613-4423-a4a2-e10db0bd1e4b/turn \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "👤 User Query:\n",
+      "\u001b[36mConvert the PDF document on https://arxiv.org/pdf/2408.09869 to DoclingDocument.\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 1: InferenceStep ----------\n",
+      "🛠️ Tool call Generated:\n",
+      "\u001b[35mTool call: convert_pdf_document_into_docling_document, Arguments: {'source': 'https://arxiv.org/pdf/2408.09869'}\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 2: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"success\": true,\\n  \"document_key\": \"2679dacbd19787abbd565a7c6b46a37a\"\\n}'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"font-weight: bold\">]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"success\": true,\\n  \"document_key\": \"2679dacbd19787abbd565a7c6b46a37a\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m)\u001b[0m\n",
+       "\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/bf6de0a0-3fcc-46c6-bc9b-3a33ce32f1e2/session/a9546fef-6613-4423-a4a2-e10db0bd1e4b/turn \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 3: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35mThe conversion of the PDF document from https://arxiv.org/pdf/2408.09869 to DoclingDocument was successful. The resulting document has a unique key '2679dacbd19787abbd565a7c6b46a37a'. You can use this key to access and manipulate the converted document in the local cache.\n",
+      "\n",
+      "You can now use the `export_docling_document_to_markdown` function with the document key to view the converted document in markdown format.\n",
+      "\u001b[0m\n",
+      "========== Query processing completed ========== \n",
+      "\n",
+      "👤 User Query:\n",
+      "\u001b[36mExport the document to markdown.\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 1: InferenceStep ----------\n",
+      "🛠️ Tool call Generated:\n",
+      "\u001b[35mTool call: export_docling_document_to_markdown, Arguments: {'document_key': '2679dacbd19787abbd565a7c6b46a37a'}\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 2: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"document_key\": \"2679dacbd19787abbd565a7c6b46a37a\",\\n  \"markdown\": \"&lt;!-- image --&gt;\\\\n\\\\n## Docling Technical Report\\\\n\\\\nVersion 1.0\\\\n\\\\nChristoph Auer Maksym Lysak Ahmed Nassar Michele Dolfi Nikolaos Livathinos Panos Vagenas Cesar Berrospi Ramis Matteo Omenetti Fabian Lindlbauer Kasper Dinkla Lokesh Mishra Yusik Kim Shubham Gupta Rafael Teixeira de Lima Valery Weber Lucas Morin Ingmar Meijer Viktor Kuropiatnyk Peter W. J. Staar\\\\n\\\\nAI4K Group, IBM Research R¨ uschlikon, Switzerland\\\\n\\\\n## Abstract\\\\n\\\\nThis technical report introduces Docling , an easy to use, self-contained, MITlicensed open-source package for PDF document conversion. It is powered by state-of-the-art specialized AI models for layout analysis (DocLayNet) and table structure recognition (TableFormer), and runs efficiently on commodity hardware in a small resource budget. The code interface allows for easy extensibility and addition of new features and models.\\\\n\\\\n## 1 Introduction\\\\n\\\\nConverting PDF documents back into a machine-processable format has been a major challenge for decades due to their huge variability in formats, weak standardization and printing-optimized characteristic, which discards most structural features and metadata. With the advent of LLMs and popular application patterns such as retrieval-augmented generation (RAG), leveraging the rich content embedded in PDFs has become ever more relevant. In the past decade, several powerful document understanding solutions have emerged on the market, most of which are commercial software, cloud offerings [3] and most recently, multi-modal vision-language models. As of today, only a handful of open-source tools cover PDF conversion, leaving a significant feature and quality gap to proprietary solutions.\\\\n\\\\nWith Docling , we open-source a very capable and efficient document conversion tool which builds on the powerful, specialized AI models and datasets for layout analysis and table structure recognition we developed and presented in the recent past [12, 13, 9]. Docling is designed as a simple, self-contained python library with permissive license, running entirely locally on commodity hardware. Its code architecture allows for easy extensibility and addition of new features and models.\\\\n\\\\nHere is what Docling delivers today:\\\\n\\\\n- Converts PDF documents to JSON or Markdown format, stable and lightning fast\\\\n- Understands detailed page layout, reading order, locates figures and recovers table structures\\\\n- Extracts metadata from the document, such as title, authors, references and language\\\\n- Optionally applies OCR, e.g. for scanned PDFs\\\\n- Can be configured to be optimal for batch-mode (i.e high throughput, low time-to-solution) or interactive mode (compromise on efficiency, low time-to-solution)\\\\n- Can leverage different accelerators (GPU, MPS, etc).\\\\n\\\\n## 2 Getting Started\\\\n\\\\nTo use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at github.com/DS4SD/docling. All required model assets 1 are downloaded to a local huggingface datasets cache on first use, unless you choose to pre-install the model assets in advance.\\\\n\\\\nDocling provides an easy code interface to convert PDF documents from file system, URLs or binary streams, and retrieve the output in either JSON or Markdown format. For convenience, separate methods are offered to convert single documents or batches of documents. A basic usage example is illustrated below. Further examples are available in the Doclign code repository.\\\\n\\\\n```\\\\nfrom docling.document_converter import DocumentConverter Large\\\\n```\\\\n\\\\n```\\\\nsource = \\\\\"https://arxiv.org/pdf/2206.01062\\\\\" # PDF path or URL converter = DocumentConverter() result = converter.convert_single(source) print(result.render_as_markdown()) # output: \\\\\"## DocLayNet: A Human -Annotated Dataset for Document -Layout Analysis [...]\\\\\"\\\\n```\\\\n\\\\nOptionally, you can configure custom pipeline features and runtime options, such as turning on or off features (e.g. OCR, table structure recognition), enforcing limits on the input document size, and defining the budget of CPU threads. Advanced usage examples and options are documented in the README file. Docling also provides a Dockerfile to demonstrate how to install and run it inside a container.\\\\n\\\\n## 3 Processing pipeline\\\\n\\\\nDocling implements a linear pipeline of operations, which execute sequentially on each given document (see Fig. 1). Each document is first parsed by a PDF backend, which retrieves the programmatic text tokens, consisting of string content and its coordinates on the page, and also renders a bitmap image of each page to support downstream operations. Then, the standard model pipeline applies a sequence of AI models independently on every page in the document to extract features and content, such as layout and table structures. Finally, the results from all pages are aggregated and passed through a post-processing stage, which augments metadata, detects the document language, infers reading-order and eventually assembles a typed document object which can be serialized to JSON or Markdown.\\\\n\\\\n## 3.1 PDF backends\\\\n\\\\nTwo basic requirements to process PDF documents in our pipeline are a) to retrieve all text content and their geometric coordinates on each page and b) to render the visual representation of each page as it would appear in a PDF viewer. Both these requirements are encapsulated in Docling\\'s PDF backend interface. While there are several open-source PDF parsing libraries available for python, we faced major obstacles with all of them for different reasons, among which were restrictive\\\\n\\\\n1 see huggingface.co/ds4sd/docling-models/\\\\n\\\\nFigure 1: Sketch of Docling\\'s default processing pipeline. The inner part of the model pipeline is easily customizable and extensible.\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\nlicensing (e.g. pymupdf [7]), poor speed or unrecoverable quality issues, such as merged text cells across far-apart text tokens or table columns (pypdfium, PyPDF) [15, 14].\\\\n\\\\nWe therefore decided to provide multiple backend choices, and additionally open-source a custombuilt PDF parser, which is based on the low-level qpdf [4] library. It is made available in a separate package named docling-parse and powers the default PDF backend in Docling. As an alternative, we provide a PDF backend relying on pypdfium , which may be a safe backup choice in certain cases, e.g. if issues are seen with particular font encodings.\\\\n\\\\n## 3.2 AI models\\\\n\\\\nAs part of Docling, we initially release two highly capable AI models to the open-source community, which have been developed and published recently by our team. The first model is a layout analysis model, an accurate object-detector for page elements [13]. The second model is TableFormer [12, 9], a state-of-the-art table structure recognition model. We provide the pre-trained weights (hosted on huggingface) and a separate package for the inference code as docling-ibm-models . Both models are also powering the open-access deepsearch-experience, our cloud-native service for knowledge exploration tasks.\\\\n\\\\n## Layout Analysis Model\\\\n\\\\nOur layout analysis model is an object-detector which predicts the bounding-boxes and classes of various elements on the image of a given page. Its architecture is derived from RT-DETR [16] and re-trained on DocLayNet [13], our popular human-annotated dataset for document-layout analysis, among other proprietary datasets. For inference, our implementation relies on the onnxruntime [5].\\\\n\\\\nThe Docling pipeline feeds page images at 72 dpi resolution, which can be processed on a single CPU with sub-second latency. All predicted bounding-box proposals for document elements are post-processed to remove overlapping proposals based on confidence and size, and then intersected with the text tokens in the PDF to group them into meaningful and complete units such as paragraphs, section titles, list items, captions, figures or tables.\\\\n\\\\n## Table Structure Recognition\\\\n\\\\nThe TableFormer model [12], first published in 2022 and since refined with a custom structure token language [9], is a vision-transformer model for table structure recovery. It can predict the logical row and column structure of a given table based on an input image, and determine which table cells belong to column headers, row headers or the table body. Compared to earlier approaches, TableFormer handles many characteristics of tables, such as partial or no borderlines, empty cells, rows or columns, cell spans and hierarchy both on column-heading or row-heading level, tables with inconsistent indentation or alignment and other complexities. For inference, our implementation relies on PyTorch [2].\\\\n\\\\nThe Docling pipeline feeds all table objects detected in the layout analysis to the TableFormer model, by providing an image-crop of the table and the included text cells. TableFormer structure predictions are matched back to the PDF cells in post-processing to avoid expensive re-transcription text in the table image. Typical tables require between 2 and 6 seconds to be processed on a standard CPU, strongly depending on the amount of included table cells.\\\\n\\\\n## OCR\\\\n\\\\nDocling provides optional support for OCR, for example to cover scanned PDFs or content in bitmaps images embedded on a page. In our initial release, we rely on EasyOCR [1], a popular thirdparty OCR library with support for many languages. Docling, by default, feeds a high-resolution page image (216 dpi) to the OCR engine, to allow capturing small print detail in decent quality. While EasyOCR delivers reasonable transcription quality, we observe that it runs fairly slow on CPU (upwards of 30 seconds per page).\\\\n\\\\nWe are actively seeking collaboration from the open-source community to extend Docling with additional OCR backends and speed improvements.\\\\n\\\\n## 3.3 Assembly\\\\n\\\\nIn the final pipeline stage, Docling assembles all prediction results produced on each page into a well-defined datatype that encapsulates a converted document, as defined in the auxiliary package docling-core . The generated document object is passed through a post-processing model which leverages several algorithms to augment features, such as detection of the document language, correcting the reading order, matching figures with captions and labelling metadata such as title, authors and references. The final output can then be serialized to JSON or transformed into a Markdown representation at the users request.\\\\n\\\\n## 3.4 Extensibility\\\\n\\\\nDocling provides a straight-forward interface to extend its capabilities, namely the model pipeline. A model pipeline constitutes the central part in the processing, following initial document parsing and preceding output assembly, and can be fully customized by sub-classing from an abstract baseclass ( BaseModelPipeline ) or cloning the default model pipeline. This effectively allows to fully customize the chain of models, add or replace models, and introduce additional pipeline configuration parameters. To use a custom model pipeline, the custom pipeline class to instantiate can be provided as an argument to the main document conversion methods. We invite everyone in the community to propose additional or alternative models and improvements.\\\\n\\\\nImplementations of model classes must satisfy the python Callable interface. The \\\\\\\\_\\\\\\\\_call\\\\\\\\_\\\\\\\\_ method must accept an iterator over page objects, and produce another iterator over the page objects which were augmented with the additional features predicted by the model, by extending the provided PagePredictions data model accordingly.\\\\n\\\\n## 4 Performance\\\\n\\\\nIn this section, we establish some reference numbers for the processing speed of Docling and the resource budget it requires. All tests in this section are run with default options on our standard test set distributed with Docling, which consists of three papers from arXiv and two IBM Redbooks, with a total of 225 pages. Measurements were taken using both available PDF backends on two different hardware systems: one MacBook Pro M3 Max, and one bare-metal server running Ubuntu 20.04 LTS on an Intel Xeon E5-2690 CPU. For reproducibility, we fixed the thread budget (through setting OMP NUM THREADS environment variable ) once to 4 (Docling default) and once to 16 (equal to full core count on the test hardware). All results are shown in Table 1.\\\\n\\\\nIf you need to run Docling in very low-resource environments, please consider configuring the pypdfium backend. While it is faster and more memory efficient than the default docling-parse backend, it will come at the expense of worse quality results, especially in table structure recovery.\\\\n\\\\nEstablishing GPU acceleration support for the AI models is currently work-in-progress and largely untested, but may work implicitly when CUDA is available and discovered by the onnxruntime and\\\\n\\\\ntorch runtimes backing the Docling pipeline. We will deliver updates on this topic at in a future version of this report.\\\\n\\\\nTable 1: Runtime characteristics of Docling with the standard model pipeline and settings, on our test dataset of 225 pages, on two different systems. OCR is disabled. We show the time-to-solution (TTS), computed throughput in pages per second, and the peak memory used (resident set size) for both the Docling-native PDF backend and for the pypdfium backend, using 4 and 16 threads.\\\\n\\\\n| CPU                              | Thread budget   | native backend   | native backend   | native backend   | pypdfium backend   | pypdfium backend   | pypdfium backend   |\\\\n|----------------------------------|-----------------|------------------|------------------|------------------|--------------------|--------------------|--------------------|\\\\n|                                  |                 | TTS              | Pages/s          | Mem              | TTS                | Pages/s            | Mem                |\\\\n| Apple M3 Max                     | 4               | 177 s 167 s      | 1.27 1.34        | 6.20 GB          | 103 s 92 s         | 2.18 2.45          | 2.56 GB            |\\\\n| (16 cores) Intel(R) Xeon E5-2690 | 16 4 16         | 375 s 244 s      | 0.60 0.92        | 6.16 GB          | 239 s 143 s        | 0.94 1.57          | 2.42 GB            |\\\\n\\\\n## 5 Applications\\\\n\\\\nThanks to the high-quality, richly structured document conversion achieved by Docling, its output qualifies for numerous downstream applications. For example, Docling can provide a base for detailed enterprise document search, passage retrieval or classification use-cases, or support knowledge extraction pipelines, allowing specific treatment of different structures in the document, such as tables, figures, section structure or references. For popular generative AI application patterns, such as retrieval-augmented generation (RAG), we provide quackling , an open-source package which capitalizes on Docling\\'s feature-rich document output to enable document-native optimized vector embedding and chunking. It plugs in seamlessly with LLM frameworks such as LlamaIndex [8]. Since Docling is fast, stable and cheap to run, it also makes for an excellent choice to build document-derived datasets. With its powerful table structure recognition, it provides significant benefit to automated knowledge-base construction [11, 10]. Docling is also integrated within the open IBM data prep kit [6], which implements scalable data transforms to build large-scale multi-modal training datasets.\\\\n\\\\n## 6 Future work and contributions\\\\n\\\\nDocling is designed to allow easy extension of the model library and pipelines. In the future, we plan to extend Docling with several more models, such as a figure-classifier model, an equationrecognition model, a code-recognition model and more. This will help improve the quality of conversion for specific types of content, as well as augment extracted document metadata with additional information. Further investment into testing and optimizing GPU acceleration as well as improving the Docling-native PDF backend are on our roadmap, too.\\\\n\\\\nWe encourage everyone to propose or implement additional features and models, and will gladly take your inputs and contributions under review . The codebase of Docling is open for use and contribution, under the MIT license agreement and in alignment with our contributing guidelines included in the Docling repository. If you use Docling in your projects, please consider citing this technical report.\\\\n\\\\n## References\\\\n\\\\n- [1] J. AI. Easyocr: Ready-to-use ocr with 80+ supported languages. https://github.com/ JaidedAI/EasyOCR , 2024. Version: 1.7.0.\\\\n- [2] J. Ansel, E. Yang, H. He, N. Gimelshein, A. Jain, M. Voznesensky, B. Bao, P. Bell, D. Berard, E. Burovski, G. Chauhan, A. Chourdia, W. Constable, A. Desmaison, Z. DeVito, E. Ellison, W. Feng, J. Gong, M. Gschwind, B. Hirsh, S. Huang, K. Kalambarkar, L. Kirsch, M. Lazos, M. Lezcano, Y. Liang, J. Liang, Y. Lu, C. Luk, B. Maher, Y. Pan, C. Puhrsch, M. Reso, M. Saroufim, M. Y. Siraichi, H. Suk, M. Suo, P. Tillet, E. Wang, X. Wang, W. Wen, S. Zhang, X. Zhao, K. Zhou, R. Zou, A. Mathews, G. Chanan, P. Wu, and S. Chintala. Pytorch 2: Faster\\\\n\\\\nmachine learning through dynamic python bytecode transformation and graph compilation. In Proceedings of the 29th ACM International Conference on Architectural Support for Programming Languages and Operating Systems, Volume 2 (ASPLOS \\'24) . ACM, 4 2024. doi: 10.1145/3620665.3640366. URL https://pytorch.org/assets/pytorch2-2.pdf .\\\\n\\\\n- [3] C. Auer, M. Dolfi, A. Carvalho, C. B. Ramis, and P. W. Staar. Delivering document conversion as a cloud service with high throughput and responsiveness. In 2022 IEEE 15th International Conference on Cloud Computing (CLOUD) , pages 363-373. IEEE, 2022.\\\\n- [4] J. Berkenbilt. Qpdf: A content-preserving pdf document transformer, 2024. URL https: //github.com/qpdf/qpdf .\\\\n- [5] O. R. developers. Onnx runtime. https://onnxruntime.ai/ , 2024. Version: 1.18.1.\\\\n- [6] IBM. Data Prep Kit: a community project to democratize and accelerate unstructured data preparation for LLM app developers, 2024. URL https://github.com/IBM/ data-prep-kit .\\\\n- [7] A. S. Inc. PyMuPDF, 2024. URL https://github.com/pymupdf/PyMuPDF .\\\\n- [8] J. Liu. LlamaIndex, 11 2022. URL https://github.com/jerryjliu/llama\\\\\\\\_index .\\\\n- [9] M. Lysak, A. Nassar, N. Livathinos, C. Auer, and P. Staar. Optimized Table Tokenization for Table Structure Recognition. In Document Analysis and Recognition - ICDAR 2023: 17th International Conference, San Jos´ e, CA, USA, August 21-26, 2023, Proceedings, Part II , pages 37-50, Berlin, Heidelberg, Aug. 2023. Springer-Verlag. ISBN 978-3-031-41678-1. doi: 10. 1007/978-3-031-41679-8 3. URL https://doi.org/10.1007/978-3-031-41679-8\\\\\\\\_3 .\\\\n- [10] L. Mishra, S. Dhibi, Y. Kim, C. Berrospi Ramis, S. Gupta, M. Dolfi, and P. Staar. Statements: Universal information extraction from tables with large language models for ESG KPIs. In D. Stammbach, J. Ni, T. Schimanski, K. Dutia, A. Singh, J. Bingler, C. Christiaen, N. Kushwaha, V. Muccione, S. A. Vaghefi, and M. Leippold, editors, Proceedings of the 1st Workshop on Natural Language Processing Meets Climate Change (ClimateNLP 2024) , pages 193-214, Bangkok, Thailand, Aug. 2024. Association for Computational Linguistics. URL https://aclanthology.org/2024.climatenlp-1.15 .\\\\n- [11] L. Morin, V. Weber, G. I. Meijer, F. Yu, and P. W. J. Staar. Patcid: an open-access dataset of chemical structures in patent documents. Nature Communications , 15(1):6532, August 2024. ISSN 2041-1723. doi: 10.1038/s41467-024-50779-y. URL https://doi.org/10.1038/ s41467-024-50779-y .\\\\n- [12] A. Nassar, N. Livathinos, M. Lysak, and P. Staar. Tableformer: Table structure understanding with transformers. In Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition , pages 4614-4623, 2022.\\\\n- [13] B. Pfitzmann, C. Auer, M. Dolfi, A. S. Nassar, and P. Staar. Doclaynet: a large humanannotated dataset for document-layout segmentation. pages 3743-3751, 2022.\\\\n- [14] pypdf Maintainers. pypdf: A Pure-Python PDF Library, 2024. URL https://github.com/ py-pdf/pypdf .\\\\n- [15] P. Team. PyPDFium2: Python bindings for PDFium, 2024. URL https://github.com/ pypdfium2-team/pypdfium2 .\\\\n- [16] Y. Zhao, W. Lv, S. Xu, J. Wei, G. Wang, Q. Dang, Y. Liu, and J. Chen. Detrs beat yolos on real-time object detection, 2023.\\\\n\\\\n## Appendix\\\\n\\\\nIn this section, we illustrate a few examples of Docling\\'s output in Markdown and JSON.\\\\n\\\\n## DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis\\\\n\\\\n## DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis\\\\n\\\\nBirgit Pfitzmann IBM Research Rueschlikon, Switzerland bpf@zurich.ibm.com\\\\n\\\\nChristoph Auer IBM Research Rueschlikon, Switzerland cau@zurich.ibm.com\\\\n\\\\nMichele Dolfi IBM Research Rueschlikon, Switzerland dol@zurich.ibm.com\\\\n\\\\nAhmed S. Nassar IBM Research Rueschlikon, Switzerland ahn@zurich.ibm.com\\\\n\\\\nPeter Staar IBM Research Rueschlikon, Switzerland taa@zurich.ibm.com\\\\n\\\\n## ABSTRACT\\\\n\\\\nAccurate document layout analysis is a key requirement for highquality PDF document conversion. With the recent availability of public, large ground-truth datasets such as PubLayNet and DocBank, deep-learning models have proven to be very effective at layout detection and segmentation. While these datasets are of adequate size to train such models, they severely lack in layout variability since they are sourced from scientific article repositories such as PubMed and arXiv only. Consequently, the accuracy of the layout segmentation drops significantly when these models are applied on more challenging and diverse layouts. In this paper, we present DocLayNet , a new, publicly available, document-layout annotation dataset in COCO format. It contains 80863 manually annotated pages from diverse data sources to represent a wide variability in layouts. For each PDF page, the layout annotations provide labelled bounding-boxes with a choice of 11 distinct classes. DocLayNet also provides a subset of double- and triple-annotated pages to determine the inter-annotator agreement. In multiple experiments, we provide baseline accuracy scores (in mAP) for a set of popular object detection models. We also demonstrate that these models fall approximately 10% behind the inter-annotator agreement. Furthermore, we provide evidence that DocLayNet is of sufficient size. Lastly, we compare models trained on PubLayNet, DocBank and DocLayNet, showing that layout predictions of the DocLayNettrained models are more robust and thus the preferred choice for general-purpose document-layout analysis.\\\\n\\\\n## CCS CONCEPTS\\\\n\\\\n· Informationsystems → Documentstructure ; · Appliedcomputing → Document analysis ; · Computing methodologies → Machine learning ; Computer vision ; Object detection ;\\\\n\\\\nPermission to make digital or hard copies of part or all of this work for personal or classroom use is granted without fee provided that copies are not made or distributed for profit or commercial advantage and that copies bear this notice and the full citation on the first page. Copyrights for third-party components of this work must be honored. For all other uses, contact the owner/author(s). KDD \\'22, August 14-18, 2022, Washington, DC, USA © 2022 Copyright held by the owner/author(s). ACM ISBN 978-1-4503-9385-0/22/08. https://doi.org/10.1145/3534678.3539043\\\\n\\\\nBirgit Pfitzmann IBM Research Rueschlikon, Switzerland bpf@zurich.ibm.com\\\\n\\\\nChristoph Auer IBM Research Rueschlikon, Switzerland cau@zurich.ibm.com\\\\n\\\\nMichele Dolfi IBM Research Rueschlikon, Switzerland dol@zurich.ibm.com\\\\n\\\\nAhmed S. Nassar IBM Research Rueschlikon, Switzerland ahn@zurich.ibm.com\\\\n\\\\nPeter Staar IBM Research Rueschlikon, Switzerland taa@zurich.ibm.com\\\\n\\\\n## ABSTRACT\\\\n\\\\nAccurate document layout analysis is a key requirement for highquality PDF document conversion. With the recent availability of public, large groundtruth datasets such as PubLayNet and DocBank, deep-learning models have proven to be very effective at layout detection and segmentation. While these datasets are of adequate size to train such models, they severely lack in layout variability since they are sourced from scientific article repositories such as PubMed and arXiv only. Consequently, the accuracy of the layout segmentation drops significantly when these models are applied on more challenging and diverse layouts. In this paper, we present DocLayNet , a new, publicly available, document-layout annotation dataset in COCO format. It contains 80863 manually annotated pages from diverse data sources to represent a wide variability in layouts. For each PDF page, the layout annotations provide labelled bounding-boxes with a choice of 11 distinct classes. DocLayNet also provides a subset of double- and triple-annotated pages to determine the inter-annotator agreement. In multiple experiments, we provide baseline accuracy scores (in mAP) for a set of popular object detection models. We also demonstrate that these models fall approximately 10% behind the inter-annotator agreement. Furthermore, we provide evidence that DocLayNet is of sufficient size. Lastly, we compare models trained on PubLayNet, DocBank and DocLayNet, showing that layout predictions of the DocLayNettrained models are more robust and thus the preferred choice for general-purpose document-layout analysis.\\\\n\\\\n## CCS CONCEPTS\\\\n\\\\nÆ Information systems → Document structure ; Æ Applied computing → Document analysis ; Æ Computing methodologies → Machine learning ; Computer vision ; Object detection ;\\\\n\\\\nPermission to make digital or hard copies of part or all of this work for personal or classroom use is granted without fee provided that copies are not made or distributed for profit or commercial advantage and that copies bear this notice and the full citation on the first page. Copyrights for third-party components of this work must be honored. For all other uses, contact the owner/author(s).\\\\n\\\\nKDD \\'22, August 14-18, 2022, Washington, DC, USA \\' 2022 Copyright held by the owner/author(s). ACM ISBN 978-1-4503-9385-0/22/08. https://doi.org/10.1145/3534678.3539043\\\\n\\\\nFigure 1: Four examples of complex page layouts across different document categories\\\\n\\\\n## KEYWORDS\\\\n\\\\nPDF document conversion, layout segmentation, object-detection, data set, Machine Learning\\\\n\\\\n## ACM Reference Format:\\\\n\\\\nBirgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar. 2022. DocLayNet: A Large Human-Annotated Dataset for DocumentLayout Analysis. In Proceedings of the 28th ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD \\'22), August 14-18, 2022, Washington, DC, USA. ACM, New York, NY, USA, 9 pages. https://doi.org/10.1145/ 3534678.3539043\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\nAGL Energy Limited  ABN 74 1 5 061 375\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\nFigure 1: Four examples of complex page layouts across different document categories\\\\n\\\\n## KEYWORDS\\\\n\\\\nPDF document conversion, layout segmentation, object-detection, data set, Machine Learning\\\\n\\\\n## ACMReference Format:\\\\n\\\\nBirgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar. 2022. DocLayNet: A Large Human-Annotated Dataset for DocumentLayout Analysis. In Proceedings of the 28th ACM SIGKDD Conference on Knowledge Discovery and Data Mining (KDD \\'22), August 14-18, 2022, Washington, DC, USA. ACM, New York, NY, USA, 9 pages. https://doi.org/10.1145/ 3534678.3539043\\\\n\\\\n1 INTRODUCTION\\\\n\\\\nDespite the substantial improvements achieved with machine-learning (ML) approaches and deep neural networks in recent years, document conversion remains a challenging problem, as demonstrated by the numerous public competitions held on this topic [1-4]. The challenge originates from the huge variability in PDF documents regarding layout, language and formats (scanned, programmatic or a combination of both). Engineering a single ML model that can be applied on all types of documents and provides high-quality layout segmentation remains to this day extremely challenging [5]. To highlight the variability in document layouts, we show a few example documents from the DocLayNet dataset in Figure 1. Figure 2: Title page of the DocLayNet paper (arxiv.org/pdf/2206.01062) - left PDF, right rendered Markdown. If recognized, metadata such as authors are appearing first under the title. Text content inside figures is currently dropped, the caption is retained and linked to the figure in the JSON representation (not shown).\\\\n\\\\nKDD \\'22, August 14-18, 2022, Washington, DC, USA Birgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar\\\\n\\\\nTable 2: Prediction performance (mAP@0.5-0.95) of object detection networks on DocLayNet test set. The MRCNN (Mask R-CNN) and FRCNN (Faster R-CNN) models with ResNet-50 or ResNet-101 backbone were trained based on the network architectures from the detectron2 model zoo (Mask R-CNN R50, R101-FPN 3x, Faster R-CNN R101-FPN 3x), with default configurations. The YOLO implementation utilized was YOLOv5x6 [13]. All models were initialised using pre-trained weights from the COCO 2017 dataset.\\\\n\\\\n|                                                                                                        | human                                                                   | MRCNN R50 R101                                                                                                          | FRCNN R101                                                  | YOLO v5x6                                                   |\\\\n|--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|-------------------------------------------------------------|\\\\n| Caption Footnote Formula List-item Page-footer Page-header Picture Section-header Table Text Title All | 84-89 83-91 83-85 87-88 93-94 85-89 69-71 83-84 77-81 84-86 60-72 82-83 | 68.4 71.5 70.9 71.8 60.1 63.4 81.2 80.8 61.6 59.3 71.9 70.0 71.7 72.7 67.6 69.3 82.2 82.9 84.6 85.8 76.7 80.4 72.4 73.5 | 70.1 73.7 63.5 81.0 58.9 72.0 72.0 68.4 82.2 85.4 79.9 73.4 | 77.7 77.2 66.2 86.2 61.1 67.9 77.1 74.6 86.3 88.1 82.7 76.8 |\\\\n\\\\nto avoid this at any cost in order to have clear, unbiased baseline numbers for human document-layout annotation. Third, we introduced the feature of snapping boxes around text segments to obtain a pixel-accurate annotation and again reduce time and effort. The CCS annotation tool automatically shrinks every user-drawn box to the minimum bounding-box around the enclosed text-cells for all purely text-based segments, which excludes only Table and Picture . For the latter, we instructed annotation staff to minimise inclusion of surrounding whitespace while including all graphical lines. A downside of snapping boxes to enclosed text cells is that some wrongly parsed PDF pages cannot be annotated correctly and need to be skipped. Fourth, we established a way to flag pages as rejected for cases where no valid annotation according to the label guidelines could be achieved. Example cases for this would be PDF pages that render incorrectly or contain layouts that are impossible to capture with non-overlapping rectangles. Such rejected pages are not contained in the final dataset. With all these measures in place, experienced annotation staff managed to annotate a single page in a typical timeframe of 20s to 60s, depending on its complexity.\\\\n\\\\n## 5 EXPERIMENTS\\\\n\\\\nThe primary goal of DocLayNet is to obtain high-quality ML models capable of accurate document-layout analysis on a wide variety of challenging layouts. As discussed in Section 2, object detection models are currently the easiest to use, due to the standardisation of ground-truth data in COCO format [16] and the availability of general frameworks such as detectron2 [17]. Furthermore, baseline numbers in PubLayNet and DocBank were obtained using standard object detection models such as Mask R-CNN and Faster R-CNN. As such, we will relate to these object detection methods in this\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\nFigure 5: Prediction performance (mAP@0.5-0.95) of a Mask R-CNNnetworkwithResNet50backbonetrainedonincreasing fractions of the DocLayNet dataset. The learning curve flattens around the 80% mark, indicating that increasing the size of the DocLayNet dataset with similar data will not yield significantly better predictions.\\\\n\\\\npaper and leave the detailed evaluation of more recent methods mentioned in Section 2 for future work.\\\\n\\\\nIn this section, we will present several aspects related to the performance of object detection models on DocLayNet. Similarly as in PubLayNet, we will evaluate the quality of their predictions using mean average precision (mAP) with 10 overlaps that range from 0.5 to 0.95 in steps of 0.05 (mAP@0.5-0.95). These scores are computed by leveraging the evaluation code provided by the COCO API [16].\\\\n\\\\n## Baselines for Object Detection\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\nThird, achienec\\\\n\\\\n## EXPERIMENTS\\\\n\\\\nchalenongayouls ground-vuth dawa such WC\\\\n\\\\nIn Table 2, we present baseline experiments (given in mAP) on Mask R-CNN [12], Faster R-CNN [11], and YOLOv5 [13]. Both training and evaluation were performed on RGB images with dimensions of 1025 × 1025 pixels. For training, we only used one annotation in case of redundantly annotated pages. As one can observe, the variation in mAP between the models is rather low, but overall between 6 and 10% lower than the mAP computed from the pairwise human annotations on triple-annotated pages. This gives a good indication that the DocLayNet dataset poses a worthwhile challenge for the research community to close the gap between human recognition and ML approaches. It is interesting to see that Mask R-CNN and Faster R-CNN produce very comparable mAP scores, indicating that pixel-based image segmentation derived from bounding-boxes does not help to obtain better predictions. On the other hand, the more recent Yolov5x model does very well and even out-performs humans on selected labels such as Text , Table and Picture . This is not entirely surprising, as Text , Table and Picture are abundant and the most visually distinctive in a document.\\\\n\\\\ncoioct dcochon modols\\\\n\\\\n## Baselines for Object Detection\\\\n\\\\nmak enbrel\\\\n\\\\nFigure 3: Page 6 of the DocLayNet paper. If recognized, metadata such as authors are appearing first under the title. Elements recognized as page headers or footers are suppressed in Markdown to deliver uninterrupted content in reading order. Tables are inserted in reading order. The paragraph in \\'5. Experiments\\' wrapping over the column end is broken up in two and interrupted by the table.\\\\n\\\\nKDD \\'22, August 14-18, 2022, Washington, DC, USA\\\\n\\\\nBirgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar\\\\n\\\\nTable 1: DocLayNet dataset overview. Along with the frequency of each class label, we present the relative occurrence (as %\\\\n\\\\nbetween pairwise annotations from the triple-annotated pages, from which we obtain accuracy ranges.\\\\n\\\\nof row \\'Total\\') in the train, test and validation sets. The inter-annotator agreement is computed as the mAP@0.5-0.95 metric\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\n| class label    | Count   | % of Total   | % of Total   | % of Total   | triple inter-annotator mAP @0.5-0.95 (%)   | triple inter-annotator mAP @0.5-0.95 (%)   | triple inter-annotator mAP @0.5-0.95 (%)   | triple inter-annotator mAP @0.5-0.95 (%)   | triple inter-annotator mAP @0.5-0.95 (%)   | triple inter-annotator mAP @0.5-0.95 (%)   | triple inter-annotator mAP @0.5-0.95 (%)   |\\\\n|----------------|---------|--------------|--------------|--------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|\\\\n| class label    | Count   | Train        | Test         | Val          | All                                        | Fin                                        | Man                                        | Sci                                        | Law                                        | Pat                                        | Ten                                        |\\\\n| Caption        | 22524   | 2.04         | 1.77         | 2.32         | 84-89                                      | 40-61                                      | 86-92                                      | 94-99                                      | 95-99                                      | 69-78                                      | n/a                                        |\\\\n| Footnote       | 6318    | 0.60         | 0.31         | 0.58         | 83-91                                      | n/a                                        | 100                                        | 62-88                                      | 85-94                                      | n/a                                        | 82-97                                      |\\\\n| Formula        | 25027   | 2.25         | 1.90         | 2.96         | 83-85                                      | n/a                                        | n/a                                        | 84-87                                      | 86-96                                      | n/a                                        | n/a                                        |\\\\n| List-item      | 185660  | 17.19        | 13.34        | 15.82        | 87-88                                      | 74-83                                      | 90-92                                      | 97-97                                      | 81-85                                      | 75-88                                      | 93-95                                      |\\\\n| Page-footer    | 70878   | 6.51         | 5.58         | 6.00         | 93-94                                      | 88-90                                      | 95-96                                      | 100                                        | 92-97                                      | 100                                        | 96-98                                      |\\\\n| Page-header    | 58022   | 5.10         | 6.70         | 5.06         | 85-89                                      | 66-76                                      | 90-94                                      | 98-100                                     | 91-92                                      | 97-99                                      | 81-86                                      |\\\\n| Picture        | 45976   | 4.21         | 2.78         | 5.31         | 69-71                                      | 56-59                                      | 82-86                                      | 69-82                                      | 80-95                                      | 66-71                                      | 59-76                                      |\\\\n| Section-header | 142884  | 12.60        | 15.77        | 12.85        | 83-84                                      | 76-81                                      | 90-92                                      | 94-95                                      | 87-94                                      | 69-73                                      | 78-86                                      |\\\\n| Table          | 34733   | 3.20         | 2.27         | 3.60         | 77-81                                      | 75-80                                      | 83-86                                      | 98-99                                      | 58-80                                      | 79-84                                      | 70-85                                      |\\\\n| Text           | 510377  | 45.82        | 49.28        | 45.00        | 84-86                                      | 81-86                                      | 88-93                                      | 89-93                                      | 87-92                                      | 71-79                                      | 87-95                                      |\\\\n| Title          | 5071    | 0.47         | 0.30         | 0.50         | 60-72                                      | 24-63                                      | 50-63                                      | 94-100                                     | 82-96                                      | 68-79                                      | 24-56                                      |\\\\n| Total          | 1107470 | 941123       | 99816        | 66531        | 82-83                                      | 71-74                                      | 79-81                                      | 89-94                                      | 86-91                                      | 71-76                                      | 68-85                                      |\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\ninclude publication repositories such as arXiv\\\\n\\\\nTable 1: DocLayNet dataset overview. Along with the frequency of each class label, we present the relative occurrence (as % of row \\\\\"Total\\\\\") in the train, test and validation sets. The inter-annotator agreement is computed as the mAP@0.5-0.95 metric between pairwise annotations from the triple-\\\\n\\\\nannotated pages, from which we obtain accuracy ranges.\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\n|                       |         | %of Total   | %of Total   | %of Total   | triple inter- annotator mAP@ 0.5-0.95 (%)   | triple inter- annotator mAP@ 0.5-0.95 (%)   | triple inter- annotator mAP@ 0.5-0.95 (%)   | triple inter- annotator mAP@ 0.5-0.95 (%)   | triple inter- annotator mAP@ 0.5-0.95 (%)   | triple inter- annotator mAP@ 0.5-0.95 (%)   | triple inter- annotator mAP@ 0.5-0.95 (%)   |\\\\n|-----------------------|---------|-------------|-------------|-------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|\\\\n| class label           | Count   | Train       | Test        | Val         | All                                         | Fin                                         | Man                                         | Sci                                         | Law                                         | Pat                                         | Ten                                         |\\\\n| Caption               | 22524   | 2.04        | 1.77        | 2.32        | 84-89                                       | 40-61                                       | 86-92                                       | 94-99                                       | 95-99                                       | 69-78                                       | n/a                                         |\\\\n| Footnote              | 6318    | 0.60        | 0.31        | 0.58        | 83-91                                       | n/a                                         | 100                                         | 62-88                                       | 85-94                                       | n/a                                         | 82-97                                       |\\\\n| Formula               | 25027   | 2.25        | 1.90        | 2.96        | 83-85                                       | n/a                                         | n/a                                         | 84-87                                       | 86-96                                       | n/a                                         | n/a                                         |\\\\n| List-item             | 185660  | 17.19       | 13.34       | 15.82       | 87-88                                       | 74-83                                       | 90-92                                       | 97-97                                       | 81-85                                       | 75-88                                       | 93-95                                       |\\\\n| Page- footer          | 70878   | 6.51        | 5.58        | 6.00        | 93-94                                       | 88-90                                       | 95-96                                       | 100                                         | 92-97                                       | 100                                         | 96-98                                       |\\\\n| Page- header offices, | 58022   | 5.10        | 6.70        | 5.06        | 85-89                                       | 66-76                                       | 90-94                                       | 98-100                                      | 91-92                                       | 97-99                                       | 81-86                                       |\\\\n| Picture               | 45976   | 4.21        | 2.78        | 5.31        | 69-71                                       | 56-59                                       | 82-86                                       | 69-82                                       | 80-95                                       | 66-71                                       | 59-76                                       |\\\\n| Section- header not   | 142884  | 12.60       | 15.77       | 12.85       | 83-84                                       | 76-81                                       | 90-92                                       | 94-95                                       | 87-94                                       | 69-73                                       | 78-86                                       |\\\\n| Table                 | 34733   | 3.20        | 2.27        | 3.60        | 77-81                                       | 75-80                                       | 83-86                                       | 98-99                                       | 58-80                                       | 79-84                                       | 70-85                                       |\\\\n| Text                  | 510377  | 45.82       | 49.28       | 45.00       | 84-86                                       | 81-86                                       | 88-93                                       | 89-93                                       | 87-92                                       | 71-79                                       | 87-95                                       |\\\\n| Title [22], a         | 5071    | 0.47        | 0.30        | 0.50        | 60-72                                       | 24-63                                       | 50-63                                       | 94-100                                      | 82-96                                       | 68-79                                       | 24-56                                       |\\\\n| Total in-             | 1107470 | 941123      | 99816       | 66531       | 82-83                                       | 71-74                                       | 79-81                                       | 89-94                                       | 86-91                                       | 71-76                                       | 68-85                                       |\\\\n\\\\n3\\\\n\\\\n, government offices,\\\\n\\\\nWe reviewed the col-\\\\n\\\\nList-item\\\\n\\\\n,\\\\n\\\\nPage-\\\\n\\\\nTitle\\\\n\\\\n, and\\\\n\\\\n.\\\\n\\\\npage. Specificity ensures that the choice of label is not ambiguous,\\\\n\\\\n&lt;!-- image --&gt;\\\\n\\\\nwe distributed the annotation workload and performed continuous be annotated. We refrained from class labels that are very specific\\\\n\\\\nonly. For phases three and four, a group of 40 dedicated annotators while coverage ensures that all meaningful items on a page can\\\\n\\\\nquality controls. Phase one and two required a small team of experts to a document category, such as\\\\n\\\\nAbstract in the\\\\n\\\\nScientific Articles were assembled and supervised.\\\\n\\\\ncategory. We also avoided class labels that are tightly linked to the\\\\n\\\\nPhase 1: Data selection and preparation.\\\\n\\\\nOur inclusion cri-\\\\n\\\\nAuthor\\\\n\\\\nAffiliation\\\\n\\\\nteria for documents were described in Section 3. A large effort went into ensuring that all documents are free to use. The data sources in DocBank, are often only distinguishable by discriminating on 3 https://arxiv.org/ Figure 4: Table 1 from the DocLayNet paper in the original PDF (A), as rendered Markdown (B) and in JSON representation (C). Spanning table cells, such as the multi-column header \\'triple interannotator mAP@0.5-0.95 (%)\\', is repeated for each column in the Markdown representation (B), which guarantees that every data point can be traced back to row and column headings only by its grid coordinates in the table. In the JSON representation, the span information is reflected in the fields of each table cell (C).\\\\n\\\\nsemantics of the text. Labels such as and\\\\n\\\\n, as seen\"\\n}'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"font-weight: bold\">]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"document_key\": \"2679dacbd19787abbd565a7c6b46a37a\",\\n  \"markdown\": \"\u001b[0m\u001b[32m<\u001b[0m\u001b[32m!-- image -->\\\\n\\\\n## Docling Technical Report\\\\n\\\\nVersion 1.0\\\\n\\\\nChristoph Auer Maksym Lysak Ahmed Nassar Michele Dolfi Nikolaos Livathinos Panos Vagenas Cesar Berrospi Ramis Matteo Omenetti Fabian Lindlbauer Kasper Dinkla Lokesh Mishra Yusik Kim Shubham Gupta Rafael Teixeira de Lima Valery Weber Lucas Morin Ingmar Meijer Viktor Kuropiatnyk Peter W. J. Staar\\\\n\\\\nAI4K Group, IBM Research R¨ uschlikon, Switzerland\\\\n\\\\n## Abstract\\\\n\\\\nThis technical report introduces Docling , an easy to use, self-contained, MITlicensed open-source package for PDF document conversion. It is powered by state-of-the-art specialized AI models for layout analysis \u001b[0m\u001b[32m(\u001b[0m\u001b[32mDocLayNet\u001b[0m\u001b[32m)\u001b[0m\u001b[32m and table structure recognition \u001b[0m\u001b[32m(\u001b[0m\u001b[32mTableFormer\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, and runs efficiently on commodity hardware in a small resource budget. The code interface allows for easy extensibility and addition of new features and models.\\\\n\\\\n## 1 Introduction\\\\n\\\\nConverting PDF documents back into a machine-processable format has been a major challenge for decades due to their huge variability in formats, weak standardization and printing-optimized characteristic, which discards most structural features and metadata. With the advent of LLMs and popular application patterns such as retrieval-augmented generation \u001b[0m\u001b[32m(\u001b[0m\u001b[32mRAG\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, leveraging the rich content embedded in PDFs has become ever more relevant. In the past decade, several powerful document understanding solutions have emerged on the market, most of which are commercial software, cloud offerings \u001b[0m\u001b[32m[\u001b[0m\u001b[32m3\u001b[0m\u001b[32m]\u001b[0m\u001b[32m and most recently, multi-modal vision-language models. As of today, only a handful of open-source tools cover PDF conversion, leaving a significant feature and quality gap to proprietary solutions.\\\\n\\\\nWith Docling , we open-source a very capable and efficient document conversion tool which builds on the powerful, specialized AI models and datasets for layout analysis and table structure recognition we developed and presented in the recent past \u001b[0m\u001b[32m[\u001b[0m\u001b[32m12, 13, 9\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. Docling is designed as a simple, self-contained python library with permissive license, running entirely locally on commodity hardware. Its code architecture allows for easy extensibility and addition of new features and models.\\\\n\\\\nHere is what Docling delivers today:\\\\n\\\\n- Converts PDF documents to JSON or Markdown format, stable and lightning fast\\\\n- Understands detailed page layout, reading order, locates figures and recovers table structures\\\\n- Extracts metadata from the document, such as title, authors, references and language\\\\n- Optionally applies OCR, e.g. for scanned PDFs\\\\n- Can be configured to be optimal for batch-mode \u001b[0m\u001b[32m(\u001b[0m\u001b[32mi.e high throughput, low time-to-solution\u001b[0m\u001b[32m)\u001b[0m\u001b[32m or interactive mode \u001b[0m\u001b[32m(\u001b[0m\u001b[32mcompromise on efficiency, low time-to-solution\u001b[0m\u001b[32m)\u001b[0m\u001b[32m\\\\n- Can leverage different accelerators \u001b[0m\u001b[32m(\u001b[0m\u001b[32mGPU, MPS, etc\u001b[0m\u001b[32m)\u001b[0m\u001b[32m.\\\\n\\\\n## 2 Getting Started\\\\n\\\\nTo use Docling, you can simply install the docling package from PyPI. Documentation and examples are available in our GitHub repository at github.com/DS4SD/docling. All required model assets 1 are downloaded to a local huggingface datasets cache on first use, unless you choose to pre-install the model assets in advance.\\\\n\\\\nDocling provides an easy code interface to convert PDF documents from file system, URLs or binary streams, and retrieve the output in either JSON or Markdown format. For convenience, separate methods are offered to convert single documents or batches of documents. A basic usage example is illustrated below. Further examples are available in the Doclign code repository.\\\\n\\\\n```\\\\nfrom docling.document_converter import DocumentConverter Large\\\\n```\\\\n\\\\n```\\\\nsource = \\\\\"https://arxiv.org/pdf/2206.01062\\\\\" # PDF path or URL converter = DocumentConverter\u001b[0m\u001b[32m(\u001b[0m\u001b[32m)\u001b[0m\u001b[32m result = converter.convert_single\u001b[0m\u001b[32m(\u001b[0m\u001b[32msource\u001b[0m\u001b[32m)\u001b[0m\u001b[32m print\u001b[0m\u001b[32m(\u001b[0m\u001b[32mresult.render_as_markdown\u001b[0m\u001b[32m(\u001b[0m\u001b[32m)\u001b[0m\u001b[32m)\u001b[0m\u001b[32m # output: \\\\\"## DocLayNet: A Human -Annotated Dataset for Document -Layout Analysis \u001b[0m\u001b[32m[\u001b[0m\u001b[32m...\u001b[0m\u001b[32m]\u001b[0m\u001b[32m\\\\\"\\\\n```\\\\n\\\\nOptionally, you can configure custom pipeline features and runtime options, such as turning on or off features \u001b[0m\u001b[32m(\u001b[0m\u001b[32me.g. OCR, table structure recognition\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, enforcing limits on the input document size, and defining the budget of CPU threads. Advanced usage examples and options are documented in the README file. Docling also provides a Dockerfile to demonstrate how to install and run it inside a container.\\\\n\\\\n## 3 Processing pipeline\\\\n\\\\nDocling implements a linear pipeline of operations, which execute sequentially on each given document \u001b[0m\u001b[32m(\u001b[0m\u001b[32msee Fig. 1\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. Each document is first parsed by a PDF backend, which retrieves the programmatic text tokens, consisting of string content and its coordinates on the page, and also renders a bitmap image of each page to support downstream operations. Then, the standard model pipeline applies a sequence of AI models independently on every page in the document to extract features and content, such as layout and table structures. Finally, the results from all pages are aggregated and passed through a post-processing stage, which augments metadata, detects the document language, infers reading-order and eventually assembles a typed document object which can be serialized to JSON or Markdown.\\\\n\\\\n## 3.1 PDF backends\\\\n\\\\nTwo basic requirements to process PDF documents in our pipeline are a\u001b[0m\u001b[32m)\u001b[0m\u001b[32m to retrieve all text content and their geometric coordinates on each page and b\u001b[0m\u001b[32m)\u001b[0m\u001b[32m to render the visual representation of each page as it would appear in a PDF viewer. Both these requirements are encapsulated in Docling\\'s PDF backend interface. While there are several open-source PDF parsing libraries available for python, we faced major obstacles with all of them for different reasons, among which were restrictive\\\\n\\\\n1 see huggingface.co/ds4sd/docling-models/\\\\n\\\\nFigure 1: Sketch of Docling\\'s default processing pipeline. The inner part of the model pipeline is easily customizable and extensible.\\\\n\\\\n<!-- image -->\\\\n\\\\nlicensing \u001b[0m\u001b[32m(\u001b[0m\u001b[32me.g. pymupdf \u001b[0m\u001b[32m[\u001b[0m\u001b[32m7\u001b[0m\u001b[32m]\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, poor speed or unrecoverable quality issues, such as merged text cells across far-apart text tokens or table columns \u001b[0m\u001b[32m(\u001b[0m\u001b[32mpypdfium, PyPDF\u001b[0m\u001b[32m)\u001b[0m\u001b[32m \u001b[0m\u001b[32m[\u001b[0m\u001b[32m15, 14\u001b[0m\u001b[32m]\u001b[0m\u001b[32m.\\\\n\\\\nWe therefore decided to provide multiple backend choices, and additionally open-source a custombuilt PDF parser, which is based on the low-level qpdf \u001b[0m\u001b[32m[\u001b[0m\u001b[32m4\u001b[0m\u001b[32m]\u001b[0m\u001b[32m library. It is made available in a separate package named docling-parse and powers the default PDF backend in Docling. As an alternative, we provide a PDF backend relying on pypdfium , which may be a safe backup choice in certain cases, e.g. if issues are seen with particular font encodings.\\\\n\\\\n## 3.2 AI models\\\\n\\\\nAs part of Docling, we initially release two highly capable AI models to the open-source community, which have been developed and published recently by our team. The first model is a layout analysis model, an accurate object-detector for page elements \u001b[0m\u001b[32m[\u001b[0m\u001b[32m13\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. The second model is TableFormer \u001b[0m\u001b[32m[\u001b[0m\u001b[32m12, 9\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, a state-of-the-art table structure recognition model. We provide the pre-trained weights \u001b[0m\u001b[32m(\u001b[0m\u001b[32mhosted on huggingface\u001b[0m\u001b[32m)\u001b[0m\u001b[32m and a separate package for the inference code as docling-ibm-models . Both models are also powering the open-access deepsearch-experience, our cloud-native service for knowledge exploration tasks.\\\\n\\\\n## Layout Analysis Model\\\\n\\\\nOur layout analysis model is an object-detector which predicts the bounding-boxes and classes of various elements on the image of a given page. Its architecture is derived from RT-DETR \u001b[0m\u001b[32m[\u001b[0m\u001b[32m16\u001b[0m\u001b[32m]\u001b[0m\u001b[32m and re-trained on DocLayNet \u001b[0m\u001b[32m[\u001b[0m\u001b[32m13\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, our popular human-annotated dataset for document-layout analysis, among other proprietary datasets. For inference, our implementation relies on the onnxruntime \u001b[0m\u001b[32m[\u001b[0m\u001b[32m5\u001b[0m\u001b[32m]\u001b[0m\u001b[32m.\\\\n\\\\nThe Docling pipeline feeds page images at 72 dpi resolution, which can be processed on a single CPU with sub-second latency. All predicted bounding-box proposals for document elements are post-processed to remove overlapping proposals based on confidence and size, and then intersected with the text tokens in the PDF to group them into meaningful and complete units such as paragraphs, section titles, list items, captions, figures or tables.\\\\n\\\\n## Table Structure Recognition\\\\n\\\\nThe TableFormer model \u001b[0m\u001b[32m[\u001b[0m\u001b[32m12\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, first published in 2022 and since refined with a custom structure token language \u001b[0m\u001b[32m[\u001b[0m\u001b[32m9\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, is a vision-transformer model for table structure recovery. It can predict the logical row and column structure of a given table based on an input image, and determine which table cells belong to column headers, row headers or the table body. Compared to earlier approaches, TableFormer handles many characteristics of tables, such as partial or no borderlines, empty cells, rows or columns, cell spans and hierarchy both on column-heading or row-heading level, tables with inconsistent indentation or alignment and other complexities. For inference, our implementation relies on PyTorch \u001b[0m\u001b[32m[\u001b[0m\u001b[32m2\u001b[0m\u001b[32m]\u001b[0m\u001b[32m.\\\\n\\\\nThe Docling pipeline feeds all table objects detected in the layout analysis to the TableFormer model, by providing an image-crop of the table and the included text cells. TableFormer structure predictions are matched back to the PDF cells in post-processing to avoid expensive re-transcription text in the table image. Typical tables require between 2 and 6 seconds to be processed on a standard CPU, strongly depending on the amount of included table cells.\\\\n\\\\n## OCR\\\\n\\\\nDocling provides optional support for OCR, for example to cover scanned PDFs or content in bitmaps images embedded on a page. In our initial release, we rely on EasyOCR \u001b[0m\u001b[32m[\u001b[0m\u001b[32m1\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, a popular thirdparty OCR library with support for many languages. Docling, by default, feeds a high-resolution page image \u001b[0m\u001b[32m(\u001b[0m\u001b[32m216 dpi\u001b[0m\u001b[32m)\u001b[0m\u001b[32m to the OCR engine, to allow capturing small print detail in decent quality. While EasyOCR delivers reasonable transcription quality, we observe that it runs fairly slow on CPU \u001b[0m\u001b[32m(\u001b[0m\u001b[32mupwards of 30 seconds per page\u001b[0m\u001b[32m)\u001b[0m\u001b[32m.\\\\n\\\\nWe are actively seeking collaboration from the open-source community to extend Docling with additional OCR backends and speed improvements.\\\\n\\\\n## 3.3 Assembly\\\\n\\\\nIn the final pipeline stage, Docling assembles all prediction results produced on each page into a well-defined datatype that encapsulates a converted document, as defined in the auxiliary package docling-core . The generated document object is passed through a post-processing model which leverages several algorithms to augment features, such as detection of the document language, correcting the reading order, matching figures with captions and labelling metadata such as title, authors and references. The final output can then be serialized to JSON or transformed into a Markdown representation at the users request.\\\\n\\\\n## 3.4 Extensibility\\\\n\\\\nDocling provides a straight-forward interface to extend its capabilities, namely the model pipeline. A model pipeline constitutes the central part in the processing, following initial document parsing and preceding output assembly, and can be fully customized by sub-classing from an abstract baseclass \u001b[0m\u001b[32m(\u001b[0m\u001b[32m BaseModelPipeline \u001b[0m\u001b[32m)\u001b[0m\u001b[32m or cloning the default model pipeline. This effectively allows to fully customize the chain of models, add or replace models, and introduce additional pipeline configuration parameters. To use a custom model pipeline, the custom pipeline class to instantiate can be provided as an argument to the main document conversion methods. We invite everyone in the community to propose additional or alternative models and improvements.\\\\n\\\\nImplementations of model classes must satisfy the python Callable interface. The \\\\\\\\_\\\\\\\\_call\\\\\\\\_\\\\\\\\_ method must accept an iterator over page objects, and produce another iterator over the page objects which were augmented with the additional features predicted by the model, by extending the provided PagePredictions data model accordingly.\\\\n\\\\n## 4 Performance\\\\n\\\\nIn this section, we establish some reference numbers for the processing speed of Docling and the resource budget it requires. All tests in this section are run with default options on our standard test set distributed with Docling, which consists of three papers from arXiv and two IBM Redbooks, with a total of 225 pages. Measurements were taken using both available PDF backends on two different hardware systems: one MacBook Pro M3 Max, and one bare-metal server running Ubuntu 20.04 LTS on an Intel Xeon E5-2690 CPU. For reproducibility, we fixed the thread budget \u001b[0m\u001b[32m(\u001b[0m\u001b[32mthrough setting OMP NUM THREADS environment variable \u001b[0m\u001b[32m)\u001b[0m\u001b[32m once to 4 \u001b[0m\u001b[32m(\u001b[0m\u001b[32mDocling default\u001b[0m\u001b[32m)\u001b[0m\u001b[32m and once to 16 \u001b[0m\u001b[32m(\u001b[0m\u001b[32mequal to full core count on the test hardware\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. All results are shown in Table 1.\\\\n\\\\nIf you need to run Docling in very low-resource environments, please consider configuring the pypdfium backend. While it is faster and more memory efficient than the default docling-parse backend, it will come at the expense of worse quality results, especially in table structure recovery.\\\\n\\\\nEstablishing GPU acceleration support for the AI models is currently work-in-progress and largely untested, but may work implicitly when CUDA is available and discovered by the onnxruntime and\\\\n\\\\ntorch runtimes backing the Docling pipeline. We will deliver updates on this topic at in a future version of this report.\\\\n\\\\nTable 1: Runtime characteristics of Docling with the standard model pipeline and settings, on our test dataset of 225 pages, on two different systems. OCR is disabled. We show the time-to-solution \u001b[0m\u001b[32m(\u001b[0m\u001b[32mTTS\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, computed throughput in pages per second, and the peak memory used \u001b[0m\u001b[32m(\u001b[0m\u001b[32mresident set size\u001b[0m\u001b[32m)\u001b[0m\u001b[32m for both the Docling-native PDF backend and for the pypdfium backend, using 4 and 16 threads.\\\\n\\\\n| CPU                              | Thread budget   | native backend   | native backend   | native backend   | pypdfium backend   | pypdfium backend   | pypdfium backend   |\\\\n|----------------------------------|-----------------|------------------|------------------|------------------|--------------------|--------------------|--------------------|\\\\n|                                  |                 | TTS              | Pages/s          | Mem              | TTS                | Pages/s            | Mem                |\\\\n| Apple M3 Max                     | 4               | 177 s 167 s      | 1.27 1.34        | 6.20 GB          | 103 s 92 s         | 2.18 2.45          | 2.56 GB            |\\\\n| \u001b[0m\u001b[32m(\u001b[0m\u001b[32m16 cores\u001b[0m\u001b[32m)\u001b[0m\u001b[32m Intel\u001b[0m\u001b[32m(\u001b[0m\u001b[32mR\u001b[0m\u001b[32m)\u001b[0m\u001b[32m Xeon E5-2690 | 16 4 16         | 375 s 244 s      | 0.60 0.92        | 6.16 GB          | 239 s 143 s        | 0.94 1.57          | 2.42 GB            |\\\\n\\\\n## 5 Applications\\\\n\\\\nThanks to the high-quality, richly structured document conversion achieved by Docling, its output qualifies for numerous downstream applications. For example, Docling can provide a base for detailed enterprise document search, passage retrieval or classification use-cases, or support knowledge extraction pipelines, allowing specific treatment of different structures in the document, such as tables, figures, section structure or references. For popular generative AI application patterns, such as retrieval-augmented generation \u001b[0m\u001b[32m(\u001b[0m\u001b[32mRAG\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, we provide quackling , an open-source package which capitalizes on Docling\\'s feature-rich document output to enable document-native optimized vector embedding and chunking. It plugs in seamlessly with LLM frameworks such as LlamaIndex \u001b[0m\u001b[32m[\u001b[0m\u001b[32m8\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. Since Docling is fast, stable and cheap to run, it also makes for an excellent choice to build document-derived datasets. With its powerful table structure recognition, it provides significant benefit to automated knowledge-base construction \u001b[0m\u001b[32m[\u001b[0m\u001b[32m11, 10\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. Docling is also integrated within the open IBM data prep kit \u001b[0m\u001b[32m[\u001b[0m\u001b[32m6\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, which implements scalable data transforms to build large-scale multi-modal training datasets.\\\\n\\\\n## 6 Future work and contributions\\\\n\\\\nDocling is designed to allow easy extension of the model library and pipelines. In the future, we plan to extend Docling with several more models, such as a figure-classifier model, an equationrecognition model, a code-recognition model and more. This will help improve the quality of conversion for specific types of content, as well as augment extracted document metadata with additional information. Further investment into testing and optimizing GPU acceleration as well as improving the Docling-native PDF backend are on our roadmap, too.\\\\n\\\\nWe encourage everyone to propose or implement additional features and models, and will gladly take your inputs and contributions under review . The codebase of Docling is open for use and contribution, under the MIT license agreement and in alignment with our contributing guidelines included in the Docling repository. If you use Docling in your projects, please consider citing this technical report.\\\\n\\\\n## References\\\\n\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m1\u001b[0m\u001b[32m]\u001b[0m\u001b[32m J. AI. Easyocr: Ready-to-use ocr with 80+ supported languages. https://github.com/ JaidedAI/EasyOCR , 2024. Version: 1.7.0.\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m2\u001b[0m\u001b[32m]\u001b[0m\u001b[32m J. Ansel, E. Yang, H. He, N. Gimelshein, A. Jain, M. Voznesensky, B. Bao, P. Bell, D. Berard, E. Burovski, G. Chauhan, A. Chourdia, W. Constable, A. Desmaison, Z. DeVito, E. Ellison, W. Feng, J. Gong, M. Gschwind, B. Hirsh, S. Huang, K. Kalambarkar, L. Kirsch, M. Lazos, M. Lezcano, Y. Liang, J. Liang, Y. Lu, C. Luk, B. Maher, Y. Pan, C. Puhrsch, M. Reso, M. Saroufim, M. Y. Siraichi, H. Suk, M. Suo, P. Tillet, E. Wang, X. Wang, W. Wen, S. Zhang, X. Zhao, K. Zhou, R. Zou, A. Mathews, G. Chanan, P. Wu, and S. Chintala. Pytorch 2: Faster\\\\n\\\\nmachine learning through dynamic python bytecode transformation and graph compilation. In Proceedings of the 29th ACM International Conference on Architectural Support for Programming Languages and Operating Systems, Volume 2 \u001b[0m\u001b[32m(\u001b[0m\u001b[32mASPLOS \\'24\u001b[0m\u001b[32m)\u001b[0m\u001b[32m . ACM, 4 2024. doi: 10.1145/3620665.3640366. URL https://pytorch.org/assets/pytorch2-2.pdf .\\\\n\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m3\u001b[0m\u001b[32m]\u001b[0m\u001b[32m C. Auer, M. Dolfi, A. Carvalho, C. B. Ramis, and P. W. Staar. Delivering document conversion as a cloud service with high throughput and responsiveness. In 2022 IEEE 15th International Conference on Cloud Computing \u001b[0m\u001b[32m(\u001b[0m\u001b[32mCLOUD\u001b[0m\u001b[32m)\u001b[0m\u001b[32m , pages 363-373. IEEE, 2022.\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m4\u001b[0m\u001b[32m]\u001b[0m\u001b[32m J. Berkenbilt. Qpdf: A content-preserving pdf document transformer, 2024. URL https: //github.com/qpdf/qpdf .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m5\u001b[0m\u001b[32m]\u001b[0m\u001b[32m O. R. developers. Onnx runtime. https://onnxruntime.ai/ , 2024. Version: 1.18.1.\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m6\u001b[0m\u001b[32m]\u001b[0m\u001b[32m IBM. Data Prep Kit: a community project to democratize and accelerate unstructured data preparation for LLM app developers, 2024. URL https://github.com/IBM/ data-prep-kit .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m7\u001b[0m\u001b[32m]\u001b[0m\u001b[32m A. S. Inc. PyMuPDF, 2024. URL https://github.com/pymupdf/PyMuPDF .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m8\u001b[0m\u001b[32m]\u001b[0m\u001b[32m J. Liu. LlamaIndex, 11 2022. URL https://github.com/jerryjliu/llama\\\\\\\\_index .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m9\u001b[0m\u001b[32m]\u001b[0m\u001b[32m M. Lysak, A. Nassar, N. Livathinos, C. Auer, and P. Staar. Optimized Table Tokenization for Table Structure Recognition. In Document Analysis and Recognition - ICDAR 2023: 17th International Conference, San Jos´ e, CA, USA, August 21-26, 2023, Proceedings, Part II , pages 37-50, Berlin, Heidelberg, Aug. 2023. Springer-Verlag. ISBN 978-3-031-41678-1. doi: 10. 1007/978-3-031-41679-8 3. URL https://doi.org/10.1007/978-3-031-41679-8\\\\\\\\_3 .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m10\u001b[0m\u001b[32m]\u001b[0m\u001b[32m L. Mishra, S. Dhibi, Y. Kim, C. Berrospi Ramis, S. Gupta, M. Dolfi, and P. Staar. Statements: Universal information extraction from tables with large language models for ESG KPIs. In D. Stammbach, J. Ni, T. Schimanski, K. Dutia, A. Singh, J. Bingler, C. Christiaen, N. Kushwaha, V. Muccione, S. A. Vaghefi, and M. Leippold, editors, Proceedings of the 1st Workshop on Natural Language Processing Meets Climate Change \u001b[0m\u001b[32m(\u001b[0m\u001b[32mClimateNLP 2024\u001b[0m\u001b[32m)\u001b[0m\u001b[32m , pages 193-214, Bangkok, Thailand, Aug. 2024. Association for Computational Linguistics. URL https://aclanthology.org/2024.climatenlp-1.15 .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m11\u001b[0m\u001b[32m]\u001b[0m\u001b[32m L. Morin, V. Weber, G. I. Meijer, F. Yu, and P. W. J. Staar. Patcid: an open-access dataset of chemical structures in patent documents. Nature Communications , 15\u001b[0m\u001b[32m(\u001b[0m\u001b[32m1\u001b[0m\u001b[32m)\u001b[0m\u001b[32m:6532, August 2024. ISSN 2041-1723. doi: 10.1038/s41467-024-50779-y. URL https://doi.org/10.1038/ s41467-024-50779-y .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m12\u001b[0m\u001b[32m]\u001b[0m\u001b[32m A. Nassar, N. Livathinos, M. Lysak, and P. Staar. Tableformer: Table structure understanding with transformers. In Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition , pages 4614-4623, 2022.\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m13\u001b[0m\u001b[32m]\u001b[0m\u001b[32m B. Pfitzmann, C. Auer, M. Dolfi, A. S. Nassar, and P. Staar. Doclaynet: a large humanannotated dataset for document-layout segmentation. pages 3743-3751, 2022.\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m14\u001b[0m\u001b[32m]\u001b[0m\u001b[32m pypdf Maintainers. pypdf: A Pure-Python PDF Library, 2024. URL https://github.com/ py-pdf/pypdf .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m15\u001b[0m\u001b[32m]\u001b[0m\u001b[32m P. Team. PyPDFium2: Python bindings for PDFium, 2024. URL https://github.com/ pypdfium2-team/pypdfium2 .\\\\n- \u001b[0m\u001b[32m[\u001b[0m\u001b[32m16\u001b[0m\u001b[32m]\u001b[0m\u001b[32m Y. Zhao, W. Lv, S. Xu, J. Wei, G. Wang, Q. Dang, Y. Liu, and J. Chen. Detrs beat yolos on real-time object detection, 2023.\\\\n\\\\n## Appendix\\\\n\\\\nIn this section, we illustrate a few examples of Docling\\'s output in Markdown and JSON.\\\\n\\\\n## DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis\\\\n\\\\n## DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis\\\\n\\\\nBirgit Pfitzmann IBM Research Rueschlikon, Switzerland bpf@zurich.ibm.com\\\\n\\\\nChristoph Auer IBM Research Rueschlikon, Switzerland cau@zurich.ibm.com\\\\n\\\\nMichele Dolfi IBM Research Rueschlikon, Switzerland dol@zurich.ibm.com\\\\n\\\\nAhmed S. Nassar IBM Research Rueschlikon, Switzerland ahn@zurich.ibm.com\\\\n\\\\nPeter Staar IBM Research Rueschlikon, Switzerland taa@zurich.ibm.com\\\\n\\\\n## ABSTRACT\\\\n\\\\nAccurate document layout analysis is a key requirement for highquality PDF document conversion. With the recent availability of public, large ground-truth datasets such as PubLayNet and DocBank, deep-learning models have proven to be very effective at layout detection and segmentation. While these datasets are of adequate size to train such models, they severely lack in layout variability since they are sourced from scientific article repositories such as PubMed and arXiv only. Consequently, the accuracy of the layout segmentation drops significantly when these models are applied on more challenging and diverse layouts. In this paper, we present DocLayNet , a new, publicly available, document-layout annotation dataset in COCO format. It contains 80863 manually annotated pages from diverse data sources to represent a wide variability in layouts. For each PDF page, the layout annotations provide labelled bounding-boxes with a choice of 11 distinct classes. DocLayNet also provides a subset of double- and triple-annotated pages to determine the inter-annotator agreement. In multiple experiments, we provide baseline accuracy scores \u001b[0m\u001b[32m(\u001b[0m\u001b[32min mAP\u001b[0m\u001b[32m)\u001b[0m\u001b[32m for a set of popular object detection models. We also demonstrate that these models fall approximately 10% behind the inter-annotator agreement. Furthermore, we provide evidence that DocLayNet is of sufficient size. Lastly, we compare models trained on PubLayNet, DocBank and DocLayNet, showing that layout predictions of the DocLayNettrained models are more robust and thus the preferred choice for general-purpose document-layout analysis.\\\\n\\\\n## CCS CONCEPTS\\\\n\\\\n· Informationsystems → Documentstructure ; · Appliedcomputing → Document analysis ; · Computing methodologies → Machine learning ; Computer vision ; Object detection ;\\\\n\\\\nPermission to make digital or hard copies of part or all of this work for personal or classroom use is granted without fee provided that copies are not made or distributed for profit or commercial advantage and that copies bear this notice and the full citation on the first page. Copyrights for third-party components of this work must be honored. For all other uses, contact the owner/author\u001b[0m\u001b[32m(\u001b[0m\u001b[32ms\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. KDD \\'22, August 14-18, 2022, Washington, DC, USA © 2022 Copyright held by the owner/author\u001b[0m\u001b[32m(\u001b[0m\u001b[32ms\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. ACM ISBN 978-1-4503-9385-0/22/08. https://doi.org/10.1145/3534678.3539043\\\\n\\\\nBirgit Pfitzmann IBM Research Rueschlikon, Switzerland bpf@zurich.ibm.com\\\\n\\\\nChristoph Auer IBM Research Rueschlikon, Switzerland cau@zurich.ibm.com\\\\n\\\\nMichele Dolfi IBM Research Rueschlikon, Switzerland dol@zurich.ibm.com\\\\n\\\\nAhmed S. Nassar IBM Research Rueschlikon, Switzerland ahn@zurich.ibm.com\\\\n\\\\nPeter Staar IBM Research Rueschlikon, Switzerland taa@zurich.ibm.com\\\\n\\\\n## ABSTRACT\\\\n\\\\nAccurate document layout analysis is a key requirement for highquality PDF document conversion. With the recent availability of public, large groundtruth datasets such as PubLayNet and DocBank, deep-learning models have proven to be very effective at layout detection and segmentation. While these datasets are of adequate size to train such models, they severely lack in layout variability since they are sourced from scientific article repositories such as PubMed and arXiv only. Consequently, the accuracy of the layout segmentation drops significantly when these models are applied on more challenging and diverse layouts. In this paper, we present DocLayNet , a new, publicly available, document-layout annotation dataset in COCO format. It contains 80863 manually annotated pages from diverse data sources to represent a wide variability in layouts. For each PDF page, the layout annotations provide labelled bounding-boxes with a choice of 11 distinct classes. DocLayNet also provides a subset of double- and triple-annotated pages to determine the inter-annotator agreement. In multiple experiments, we provide baseline accuracy scores \u001b[0m\u001b[32m(\u001b[0m\u001b[32min mAP\u001b[0m\u001b[32m)\u001b[0m\u001b[32m for a set of popular object detection models. We also demonstrate that these models fall approximately 10% behind the inter-annotator agreement. Furthermore, we provide evidence that DocLayNet is of sufficient size. Lastly, we compare models trained on PubLayNet, DocBank and DocLayNet, showing that layout predictions of the DocLayNettrained models are more robust and thus the preferred choice for general-purpose document-layout analysis.\\\\n\\\\n## CCS CONCEPTS\\\\n\\\\nÆ Information systems → Document structure ; Æ Applied computing → Document analysis ; Æ Computing methodologies → Machine learning ; Computer vision ; Object detection ;\\\\n\\\\nPermission to make digital or hard copies of part or all of this work for personal or classroom use is granted without fee provided that copies are not made or distributed for profit or commercial advantage and that copies bear this notice and the full citation on the first page. Copyrights for third-party components of this work must be honored. For all other uses, contact the owner/author\u001b[0m\u001b[32m(\u001b[0m\u001b[32ms\u001b[0m\u001b[32m)\u001b[0m\u001b[32m.\\\\n\\\\nKDD \\'22, August 14-18, 2022, Washington, DC, USA \\' 2022 Copyright held by the owner/author\u001b[0m\u001b[32m(\u001b[0m\u001b[32ms\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. ACM ISBN 978-1-4503-9385-0/22/08. https://doi.org/10.1145/3534678.3539043\\\\n\\\\nFigure 1: Four examples of complex page layouts across different document categories\\\\n\\\\n## KEYWORDS\\\\n\\\\nPDF document conversion, layout segmentation, object-detection, data set, Machine Learning\\\\n\\\\n## ACM Reference Format:\\\\n\\\\nBirgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar. 2022. DocLayNet: A Large Human-Annotated Dataset for DocumentLayout Analysis. In Proceedings of the 28th ACM SIGKDD Conference on Knowledge Discovery and Data Mining \u001b[0m\u001b[32m(\u001b[0m\u001b[32mKDD \\'22\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, August 14-18, 2022, Washington, DC, USA. ACM, New York, NY, USA, 9 pages. https://doi.org/10.1145/ 3534678.3539043\\\\n\\\\n<!-- image -->\\\\n\\\\n<!-- image -->\\\\n\\\\nAGL Energy Limited  ABN 74 1 5 061 375\\\\n\\\\n<!-- image -->\\\\n\\\\n<!-- image -->\\\\n\\\\nFigure 1: Four examples of complex page layouts across different document categories\\\\n\\\\n## KEYWORDS\\\\n\\\\nPDF document conversion, layout segmentation, object-detection, data set, Machine Learning\\\\n\\\\n## ACMReference Format:\\\\n\\\\nBirgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar. 2022. DocLayNet: A Large Human-Annotated Dataset for DocumentLayout Analysis. In Proceedings of the 28th ACM SIGKDD Conference on Knowledge Discovery and Data Mining \u001b[0m\u001b[32m(\u001b[0m\u001b[32mKDD \\'22\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, August 14-18, 2022, Washington, DC, USA. ACM, New York, NY, USA, 9 pages. https://doi.org/10.1145/ 3534678.3539043\\\\n\\\\n1 INTRODUCTION\\\\n\\\\nDespite the substantial improvements achieved with machine-learning \u001b[0m\u001b[32m(\u001b[0m\u001b[32mML\u001b[0m\u001b[32m)\u001b[0m\u001b[32m approaches and deep neural networks in recent years, document conversion remains a challenging problem, as demonstrated by the numerous public competitions held on this topic \u001b[0m\u001b[32m[\u001b[0m\u001b[32m1-4\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. The challenge originates from the huge variability in PDF documents regarding layout, language and formats \u001b[0m\u001b[32m(\u001b[0m\u001b[32mscanned, programmatic or a combination of both\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. Engineering a single ML model that can be applied on all types of documents and provides high-quality layout segmentation remains to this day extremely challenging \u001b[0m\u001b[32m[\u001b[0m\u001b[32m5\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. To highlight the variability in document layouts, we show a few example documents from the DocLayNet dataset in Figure 1. Figure 2: Title page of the DocLayNet paper \u001b[0m\u001b[32m(\u001b[0m\u001b[32marxiv.org/pdf/2206.01062\u001b[0m\u001b[32m)\u001b[0m\u001b[32m - left PDF, right rendered Markdown. If recognized, metadata such as authors are appearing first under the title. Text content inside figures is currently dropped, the caption is retained and linked to the figure in the JSON representation \u001b[0m\u001b[32m(\u001b[0m\u001b[32mnot shown\u001b[0m\u001b[32m)\u001b[0m\u001b[32m.\\\\n\\\\nKDD \\'22, August 14-18, 2022, Washington, DC, USA Birgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar\\\\n\\\\nTable 2: Prediction performance \u001b[0m\u001b[32m(\u001b[0m\u001b[32mmAP@0.5-0.95\u001b[0m\u001b[32m)\u001b[0m\u001b[32m of object detection networks on DocLayNet test set. The MRCNN \u001b[0m\u001b[32m(\u001b[0m\u001b[32mMask R-CNN\u001b[0m\u001b[32m)\u001b[0m\u001b[32m and FRCNN \u001b[0m\u001b[32m(\u001b[0m\u001b[32mFaster R-CNN\u001b[0m\u001b[32m)\u001b[0m\u001b[32m models with ResNet-50 or ResNet-101 backbone were trained based on the network architectures from the detectron2 model zoo \u001b[0m\u001b[32m(\u001b[0m\u001b[32mMask R-CNN R50, R101-FPN 3x, Faster R-CNN R101-FPN 3x\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, with default configurations. The YOLO implementation utilized was YOLOv5x6 \u001b[0m\u001b[32m[\u001b[0m\u001b[32m13\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. All models were initialised using pre-trained weights from the COCO 2017 dataset.\\\\n\\\\n|                                                                                                        | human                                                                   | MRCNN R50 R101                                                                                                          | FRCNN R101                                                  | YOLO v5x6                                                   |\\\\n|--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|-------------------------------------------------------------|\\\\n| Caption Footnote Formula List-item Page-footer Page-header Picture Section-header Table Text Title All | 84-89 83-91 83-85 87-88 93-94 85-89 69-71 83-84 77-81 84-86 60-72 82-83 | 68.4 71.5 70.9 71.8 60.1 63.4 81.2 80.8 61.6 59.3 71.9 70.0 71.7 72.7 67.6 69.3 82.2 82.9 84.6 85.8 76.7 80.4 72.4 73.5 | 70.1 73.7 63.5 81.0 58.9 72.0 72.0 68.4 82.2 85.4 79.9 73.4 | 77.7 77.2 66.2 86.2 61.1 67.9 77.1 74.6 86.3 88.1 82.7 76.8 |\\\\n\\\\nto avoid this at any cost in order to have clear, unbiased baseline numbers for human document-layout annotation. Third, we introduced the feature of snapping boxes around text segments to obtain a pixel-accurate annotation and again reduce time and effort. The CCS annotation tool automatically shrinks every user-drawn box to the minimum bounding-box around the enclosed text-cells for all purely text-based segments, which excludes only Table and Picture . For the latter, we instructed annotation staff to minimise inclusion of surrounding whitespace while including all graphical lines. A downside of snapping boxes to enclosed text cells is that some wrongly parsed PDF pages cannot be annotated correctly and need to be skipped. Fourth, we established a way to flag pages as rejected for cases where no valid annotation according to the label guidelines could be achieved. Example cases for this would be PDF pages that render incorrectly or contain layouts that are impossible to capture with non-overlapping rectangles. Such rejected pages are not contained in the final dataset. With all these measures in place, experienced annotation staff managed to annotate a single page in a typical timeframe of 20s to 60s, depending on its complexity.\\\\n\\\\n## 5 EXPERIMENTS\\\\n\\\\nThe primary goal of DocLayNet is to obtain high-quality ML models capable of accurate document-layout analysis on a wide variety of challenging layouts. As discussed in Section 2, object detection models are currently the easiest to use, due to the standardisation of ground-truth data in COCO format \u001b[0m\u001b[32m[\u001b[0m\u001b[32m16\u001b[0m\u001b[32m]\u001b[0m\u001b[32m and the availability of general frameworks such as detectron2 \u001b[0m\u001b[32m[\u001b[0m\u001b[32m17\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. Furthermore, baseline numbers in PubLayNet and DocBank were obtained using standard object detection models such as Mask R-CNN and Faster R-CNN. As such, we will relate to these object detection methods in this\\\\n\\\\n<!-- image -->\\\\n\\\\nFigure 5: Prediction performance \u001b[0m\u001b[32m(\u001b[0m\u001b[32mmAP@0.5-0.95\u001b[0m\u001b[32m)\u001b[0m\u001b[32m of a Mask R-CNNnetworkwithResNet50backbonetrainedonincreasing fractions of the DocLayNet dataset. The learning curve flattens around the 80% mark, indicating that increasing the size of the DocLayNet dataset with similar data will not yield significantly better predictions.\\\\n\\\\npaper and leave the detailed evaluation of more recent methods mentioned in Section 2 for future work.\\\\n\\\\nIn this section, we will present several aspects related to the performance of object detection models on DocLayNet. Similarly as in PubLayNet, we will evaluate the quality of their predictions using mean average precision \u001b[0m\u001b[32m(\u001b[0m\u001b[32mmAP\u001b[0m\u001b[32m)\u001b[0m\u001b[32m with 10 overlaps that range from 0.5 to 0.95 in steps of 0.05 \u001b[0m\u001b[32m(\u001b[0m\u001b[32mmAP@0.5-0.95\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. These scores are computed by leveraging the evaluation code provided by the COCO API \u001b[0m\u001b[32m[\u001b[0m\u001b[32m16\u001b[0m\u001b[32m]\u001b[0m\u001b[32m.\\\\n\\\\n## Baselines for Object Detection\\\\n\\\\n<!-- image -->\\\\n\\\\nThird, achienec\\\\n\\\\n## EXPERIMENTS\\\\n\\\\nchalenongayouls ground-vuth dawa such WC\\\\n\\\\nIn Table 2, we present baseline experiments \u001b[0m\u001b[32m(\u001b[0m\u001b[32mgiven in mAP\u001b[0m\u001b[32m)\u001b[0m\u001b[32m on Mask R-CNN \u001b[0m\u001b[32m[\u001b[0m\u001b[32m12\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, Faster R-CNN \u001b[0m\u001b[32m[\u001b[0m\u001b[32m11\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, and YOLOv5 \u001b[0m\u001b[32m[\u001b[0m\u001b[32m13\u001b[0m\u001b[32m]\u001b[0m\u001b[32m. Both training and evaluation were performed on RGB images with dimensions of 1025 × 1025 pixels. For training, we only used one annotation in case of redundantly annotated pages. As one can observe, the variation in mAP between the models is rather low, but overall between 6 and 10% lower than the mAP computed from the pairwise human annotations on triple-annotated pages. This gives a good indication that the DocLayNet dataset poses a worthwhile challenge for the research community to close the gap between human recognition and ML approaches. It is interesting to see that Mask R-CNN and Faster R-CNN produce very comparable mAP scores, indicating that pixel-based image segmentation derived from bounding-boxes does not help to obtain better predictions. On the other hand, the more recent Yolov5x model does very well and even out-performs humans on selected labels such as Text , Table and Picture . This is not entirely surprising, as Text , Table and Picture are abundant and the most visually distinctive in a document.\\\\n\\\\ncoioct dcochon modols\\\\n\\\\n## Baselines for Object Detection\\\\n\\\\nmak enbrel\\\\n\\\\nFigure 3: Page 6 of the DocLayNet paper. If recognized, metadata such as authors are appearing first under the title. Elements recognized as page headers or footers are suppressed in Markdown to deliver uninterrupted content in reading order. Tables are inserted in reading order. The paragraph in \\'5. Experiments\\' wrapping over the column end is broken up in two and interrupted by the table.\\\\n\\\\nKDD \\'22, August 14-18, 2022, Washington, DC, USA\\\\n\\\\nBirgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar, and Peter Staar\\\\n\\\\nTable 1: DocLayNet dataset overview. Along with the frequency of each class label, we present the relative occurrence \u001b[0m\u001b[32m(\u001b[0m\u001b[32mas %\\\\n\\\\nbetween pairwise annotations from the triple-annotated pages, from which we obtain accuracy ranges.\\\\n\\\\nof row \\'Total\\'\u001b[0m\u001b[32m)\u001b[0m\u001b[32m in the train, test and validation sets. The inter-annotator agreement is computed as the mAP@0.5-0.95 metric\\\\n\\\\n<!-- image -->\\\\n\\\\n<!-- image -->\\\\n\\\\n| class label    | Count   | % of Total   | % of Total   | % of Total   | triple inter-annotator mAP @0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter-annotator mAP @0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter-annotator mAP @0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter-annotator mAP @0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter-annotator mAP @0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter-annotator mAP @0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter-annotator mAP @0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   |\\\\n|----------------|---------|--------------|--------------|--------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|--------------------------------------------|\\\\n| class label    | Count   | Train        | Test         | Val          | All                                        | Fin                                        | Man                                        | Sci                                        | Law                                        | Pat                                        | Ten                                        |\\\\n| Caption        | 22524   | 2.04         | 1.77         | 2.32         | 84-89                                      | 40-61                                      | 86-92                                      | 94-99                                      | 95-99                                      | 69-78                                      | n/a                                        |\\\\n| Footnote       | 6318    | 0.60         | 0.31         | 0.58         | 83-91                                      | n/a                                        | 100                                        | 62-88                                      | 85-94                                      | n/a                                        | 82-97                                      |\\\\n| Formula        | 25027   | 2.25         | 1.90         | 2.96         | 83-85                                      | n/a                                        | n/a                                        | 84-87                                      | 86-96                                      | n/a                                        | n/a                                        |\\\\n| List-item      | 185660  | 17.19        | 13.34        | 15.82        | 87-88                                      | 74-83                                      | 90-92                                      | 97-97                                      | 81-85                                      | 75-88                                      | 93-95                                      |\\\\n| Page-footer    | 70878   | 6.51         | 5.58         | 6.00         | 93-94                                      | 88-90                                      | 95-96                                      | 100                                        | 92-97                                      | 100                                        | 96-98                                      |\\\\n| Page-header    | 58022   | 5.10         | 6.70         | 5.06         | 85-89                                      | 66-76                                      | 90-94                                      | 98-100                                     | 91-92                                      | 97-99                                      | 81-86                                      |\\\\n| Picture        | 45976   | 4.21         | 2.78         | 5.31         | 69-71                                      | 56-59                                      | 82-86                                      | 69-82                                      | 80-95                                      | 66-71                                      | 59-76                                      |\\\\n| Section-header | 142884  | 12.60        | 15.77        | 12.85        | 83-84                                      | 76-81                                      | 90-92                                      | 94-95                                      | 87-94                                      | 69-73                                      | 78-86                                      |\\\\n| Table          | 34733   | 3.20         | 2.27         | 3.60         | 77-81                                      | 75-80                                      | 83-86                                      | 98-99                                      | 58-80                                      | 79-84                                      | 70-85                                      |\\\\n| Text           | 510377  | 45.82        | 49.28        | 45.00        | 84-86                                      | 81-86                                      | 88-93                                      | 89-93                                      | 87-92                                      | 71-79                                      | 87-95                                      |\\\\n| Title          | 5071    | 0.47         | 0.30         | 0.50         | 60-72                                      | 24-63                                      | 50-63                                      | 94-100                                     | 82-96                                      | 68-79                                      | 24-56                                      |\\\\n| Total          | 1107470 | 941123       | 99816        | 66531        | 82-83                                      | 71-74                                      | 79-81                                      | 89-94                                      | 86-91                                      | 71-76                                      | 68-85                                      |\\\\n\\\\n<!-- image -->\\\\n\\\\ninclude publication repositories such as arXiv\\\\n\\\\nTable 1: DocLayNet dataset overview. Along with the frequency of each class label, we present the relative occurrence \u001b[0m\u001b[32m(\u001b[0m\u001b[32mas % of row \\\\\"Total\\\\\"\u001b[0m\u001b[32m)\u001b[0m\u001b[32m in the train, test and validation sets. The inter-annotator agreement is computed as the mAP@0.5-0.95 metric between pairwise annotations from the triple-\\\\n\\\\nannotated pages, from which we obtain accuracy ranges.\\\\n\\\\n<!-- image -->\\\\n\\\\n|                       |         | %of Total   | %of Total   | %of Total   | triple inter- annotator mAP@ 0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter- annotator mAP@ 0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter- annotator mAP@ 0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter- annotator mAP@ 0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter- annotator mAP@ 0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter- annotator mAP@ 0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   | triple inter- annotator mAP@ 0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m   |\\\\n|-----------------------|---------|-------------|-------------|-------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|\\\\n| class label           | Count   | Train       | Test        | Val         | All                                         | Fin                                         | Man                                         | Sci                                         | Law                                         | Pat                                         | Ten                                         |\\\\n| Caption               | 22524   | 2.04        | 1.77        | 2.32        | 84-89                                       | 40-61                                       | 86-92                                       | 94-99                                       | 95-99                                       | 69-78                                       | n/a                                         |\\\\n| Footnote              | 6318    | 0.60        | 0.31        | 0.58        | 83-91                                       | n/a                                         | 100                                         | 62-88                                       | 85-94                                       | n/a                                         | 82-97                                       |\\\\n| Formula               | 25027   | 2.25        | 1.90        | 2.96        | 83-85                                       | n/a                                         | n/a                                         | 84-87                                       | 86-96                                       | n/a                                         | n/a                                         |\\\\n| List-item             | 185660  | 17.19       | 13.34       | 15.82       | 87-88                                       | 74-83                                       | 90-92                                       | 97-97                                       | 81-85                                       | 75-88                                       | 93-95                                       |\\\\n| Page- footer          | 70878   | 6.51        | 5.58        | 6.00        | 93-94                                       | 88-90                                       | 95-96                                       | 100                                         | 92-97                                       | 100                                         | 96-98                                       |\\\\n| Page- header offices, | 58022   | 5.10        | 6.70        | 5.06        | 85-89                                       | 66-76                                       | 90-94                                       | 98-100                                      | 91-92                                       | 97-99                                       | 81-86                                       |\\\\n| Picture               | 45976   | 4.21        | 2.78        | 5.31        | 69-71                                       | 56-59                                       | 82-86                                       | 69-82                                       | 80-95                                       | 66-71                                       | 59-76                                       |\\\\n| Section- header not   | 142884  | 12.60       | 15.77       | 12.85       | 83-84                                       | 76-81                                       | 90-92                                       | 94-95                                       | 87-94                                       | 69-73                                       | 78-86                                       |\\\\n| Table                 | 34733   | 3.20        | 2.27        | 3.60        | 77-81                                       | 75-80                                       | 83-86                                       | 98-99                                       | 58-80                                       | 79-84                                       | 70-85                                       |\\\\n| Text                  | 510377  | 45.82       | 49.28       | 45.00       | 84-86                                       | 81-86                                       | 88-93                                       | 89-93                                       | 87-92                                       | 71-79                                       | 87-95                                       |\\\\n| Title \u001b[0m\u001b[32m[\u001b[0m\u001b[32m22\u001b[0m\u001b[32m]\u001b[0m\u001b[32m, a         | 5071    | 0.47        | 0.30        | 0.50        | 60-72                                       | 24-63                                       | 50-63                                       | 94-100                                      | 82-96                                       | 68-79                                       | 24-56                                       |\\\\n| Total in-             | 1107470 | 941123      | 99816       | 66531       | 82-83                                       | 71-74                                       | 79-81                                       | 89-94                                       | 86-91                                       | 71-76                                       | 68-85                                       |\\\\n\\\\n3\\\\n\\\\n, government offices,\\\\n\\\\nWe reviewed the col-\\\\n\\\\nList-item\\\\n\\\\n,\\\\n\\\\nPage-\\\\n\\\\nTitle\\\\n\\\\n, and\\\\n\\\\n.\\\\n\\\\npage. Specificity ensures that the choice of label is not ambiguous,\\\\n\\\\n<!-- image --\u001b[0m\u001b[32m>\u001b[0m\u001b[32m\\\\n\\\\nwe distributed the annotation workload and performed continuous be annotated. We refrained from class labels that are very specific\\\\n\\\\nonly. For phases three and four, a group of 40 dedicated annotators while coverage ensures that all meaningful items on a page can\\\\n\\\\nquality controls. Phase one and two required a small team of experts to a document category, such as\\\\n\\\\nAbstract in the\\\\n\\\\nScientific Articles were assembled and supervised.\\\\n\\\\ncategory. We also avoided class labels that are tightly linked to the\\\\n\\\\nPhase 1: Data selection and preparation.\\\\n\\\\nOur inclusion cri-\\\\n\\\\nAuthor\\\\n\\\\nAffiliation\\\\n\\\\nteria for documents were described in Section 3. A large effort went into ensuring that all documents are free to use. The data sources in DocBank, are often only distinguishable by discriminating on 3 https://arxiv.org/ Figure 4: Table 1 from the DocLayNet paper in the original PDF \u001b[0m\u001b[32m(\u001b[0m\u001b[32mA\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, as rendered Markdown \u001b[0m\u001b[32m(\u001b[0m\u001b[32mB\u001b[0m\u001b[32m)\u001b[0m\u001b[32m and in JSON representation \u001b[0m\u001b[32m(\u001b[0m\u001b[32mC\u001b[0m\u001b[32m)\u001b[0m\u001b[32m. Spanning table cells, such as the multi-column header \\'triple interannotator mAP@0.5-0.95 \u001b[0m\u001b[32m(\u001b[0m\u001b[32m%\u001b[0m\u001b[32m)\u001b[0m\u001b[32m\\', is repeated for each column in the Markdown representation \u001b[0m\u001b[32m(\u001b[0m\u001b[32mB\u001b[0m\u001b[32m)\u001b[0m\u001b[32m, which guarantees that every data point can be traced back to row and column headings only by its grid coordinates in the table. In the JSON representation, the span information is reflected in the fields of each table cell \u001b[0m\u001b[32m(\u001b[0m\u001b[32mC\u001b[0m\u001b[32m)\u001b[0m\u001b[32m.\\\\n\\\\nsemantics of the text. Labels such as and\\\\n\\\\n, as seen\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m)\u001b[0m\n",
+       "\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/bf6de0a0-3fcc-46c6-bc9b-3a33ce32f1e2/session/a9546fef-6613-4423-a4a2-e10db0bd1e4b/turn \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 3: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35mThis is a research paper on a dataset called DocLayNet, which is a collection of annotated documents for natural language processing tasks. The paper describes the creation and characteristics of the dataset, including its size, annotation process, and quality control measures.\n",
+      "\n",
+      "Here are some key points from the paper:\n",
+      "\n",
+      "1. **Dataset size**: The DocLayNet dataset consists of 1,107,470 documents, with a total of 10,714,190 annotated instances.\n",
+      "2. **Annotation process**: The annotations were performed by a team of 40 dedicated annotators, who worked in three phases: data selection and preparation, annotation, and quality control.\n",
+      "3. **Labeling scheme**: The dataset includes 11 labels, including:\n",
+      "\t* Caption\n",
+      "\t* Footnote\n",
+      "\t* Formula\n",
+      "\t* List item\n",
+      "\t* Page header\n",
+      "\t* Picture\n",
+      "\t* Section header\n",
+      "\t* Table\n",
+      "\t* Text\n",
+      "\t* Title\n",
+      "\t* Total\n",
+      "4. **Annotation guidelines**: Annotators were instructed to use a specific labeling scheme, which ensures that the choice of label is not ambiguous and covers all meaningful items on a page.\n",
+      "5. **Quality control**: The dataset underwent continuous quality control measures to ensure consistency and accuracy in annotations.\n",
+      "6. **Data sources**: The data was sourced from various places, including government offices, scientific articles, and other documents.\n",
+      "\n",
+      "The paper also provides some statistics about the dataset, such as:\n",
+      "\n",
+      "* 45.82% of the instances are labeled as \"Text\"\n",
+      "* 3.20% of the instances are labeled as \"Table\"\n",
+      "* 2.25% of the instances are labeled as \"Formula\"\n",
+      "* The average length of a document is around 200 words\n",
+      "\n",
+      "Overall, the DocLayNet dataset appears to be a comprehensive and well-annotated collection of documents for natural language processing tasks, with a focus on text classification and information extraction.\n",
+      "\u001b[0m\n",
+      "========== Query processing completed ========== \n",
+      "\n",
+      "👤 User Query:\n",
+      "\u001b[36mWrite a summary of the document content.\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 1: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35mThe document discusses the creation and characteristics of the DocLayNet dataset, a large collection of annotated documents for natural language processing tasks. The dataset consists of 1,107,470 documents with 10,714,190 annotated instances, covering 11 labels such as caption, footnote, formula, list item, page header, picture, section header, table, text, title, and total. The annotations were performed by a team of 40 dedicated annotators using a specific labeling scheme to ensure consistency and accuracy. The dataset is sourced from various places, including government offices, scientific articles, and other documents. The document provides statistics about the dataset, such as the distribution of labels and the average length of a document. The goal of DocLayNet is to provide a comprehensive resource for natural language processing tasks, enabling researchers to develop and evaluate models that can accurately extract information from unstructured text data.\n",
+      "\u001b[0m\n",
+      "========== Query processing completed ========== \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "user_prompts = [\n",
+    "    \"Convert the PDF document on https://arxiv.org/pdf/2408.09869 to DoclingDocument.\",\n",
+    "    \"Export the document to markdown.\",\n",
+    "    \"Write a summary of the document content.\",\n",
+    "]\n",
+    "session_id = agent.create_session(f\"docling-session_{uuid.uuid4()}\")\n",
+    "\n",
+    "for i, prompt in enumerate(user_prompts):\n",
+    "    user_printer(prompt)\n",
+    "    response = agent.create_turn(\n",
+    "        messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    "        session_id=session_id,\n",
+    "        stream=settings.stream,\n",
+    "    )\n",
+    "    if settings.stream:\n",
+    "        for log in EventLogger().log(response):\n",
+    "            log.print()\n",
+    "    else:\n",
+    "        step_printer(\n",
+    "            response.steps\n",
+    "        )  # print the steps of an agent's response in a formatted way."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bd0ada6",
+   "metadata": {},
+   "source": [
+    "## Defining our Agent - ReAct"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85a54284",
+   "metadata": {},
+   "source": [
+    "We can also define our agent to be more autonomous and perform the same task with a single prompt instead of a chain. To do this, we leverage Llama Stack's **ReAct agent**, which has the ability to loop through the *Reason then Act* iterations, thinking through the problem and then using tools until it determines that it's task has been completed successfully.  \n",
+    "\n",
+    "Unlike prompt chaining which follows fixed steps, ReAct dynamically breaks down tasks and adapts its approach based on the results of each step. This makes it more flexible and capable of handling complex, real-world queries effectively.\n",
+    "\n",
+    "In this example, we will leverage the generation tools of **Docling MCP** to:\n",
+    "- create a new `DoclingDocument`\n",
+    "- add a title and paragraphs\n",
+    "- export the resulting document into a file in markdown format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "214b0942",
+   "metadata": {},
+   "source": [
+    "The purpose of the code below is just to show the instructions sent to the LLM to complete the task. They incorporate the description of the Docling MCP tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "76fbe223",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: GET http://localhost:8321/v1/tools?toolgroup_id=mcp%3A%3Adocling \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "You are an expert assistant who can solve any task using tool calls. You will be given a task to solve as best you can.\n",
+      "To do so, you have been given access to the following tools: is_document_in_local_cache, convert_pdf_document_into_docling_document, create_new_docling_document, export_docling_document_to_markdown, save_docling_document, add_title_to_docling_document, add_section_heading_to_docling_document, add_paragraph_to_docling_document, open_list_in_docling_document, close_list_in_docling_document, add_list_items_to_list_in_docling_document, add_table_in_html_format_to_docling_document, get_overview_of_document_anchors, get_text_of_document_item_at_anchor, update_text_of_document_item_at_anchor, delete_document_items_at_anchors\n",
+      "\n",
+      "You must always respond in the following JSON format:\n",
+      "{\n",
+      "    \"thought\": $THOUGHT_PROCESS,\n",
+      "    \"action\": {\n",
+      "        \"tool_name\": $TOOL_NAME,\n",
+      "        \"tool_params\": $TOOL_PARAMS\n",
+      "    },\n",
+      "    \"answer\": $ANSWER\n",
+      "}\n",
+      "\n",
+      "Specifically, this json should have a `thought` key, a `action` key and an `answer` key.\n",
+      "\n",
+      "The `action` key should specify the $TOOL_NAME the name of the tool to use and the `tool_params` key should specify the parameters key as input to the tool.\n",
+      "\n",
+      "Make sure to have the $TOOL_PARAMS as a list of dictionaries in the right format for the tool you are using, and do not put variable names as input if you can find the right values.\n",
+      "\n",
+      "You should always think about one action to take, and have the `thought` key contain your thought process about this action.\n",
+      "If the tool responds, the tool will return an observation containing result of the action. \n",
+      "... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The action key must only use a SINGLE tool at a time.)\n",
+      "\n",
+      "You can use the result of the previous action as input for the next action.\n",
+      "The observation will always be the response from calling the tool: it can represent a file, like \"image_1.jpg\". You do not need to generate them, it will be provided to you. \n",
+      "Then you can use it as input for the next action. You can do it for instance as follows:\n",
+      "\n",
+      "Observation: \"image_1.jpg\"\n",
+      "{\n",
+      "    \"thought\": \"I need to transform the image that I received in the previous observation to make it green.\",\n",
+      "    \"action\": {\n",
+      "        \"tool_name\": \"image_transformer\",\n",
+      "        \"tool_params\": [{\"name\": \"image\"}, {\"value\": \"image_1.jpg\"}]\n",
+      "    },\n",
+      "    \"answer\": null\n",
+      "}\n",
+      "\n",
+      "\n",
+      "To provide the final answer to the task, use the `answer` key. It is the only way to complete the task, else you will be stuck on a loop. So your final output should look like this:\n",
+      "Observation: \"your observation\"\n",
+      "\n",
+      "{\n",
+      "    \"thought\": \"you thought process\",\n",
+      "    \"action\": null,\n",
+      "    \"answer\": \"insert your final answer here\"\n",
+      "}\n",
+      "\n",
+      "Here are a few examples using notional tools:\n",
+      "---\n",
+      "Task: \"Generate an image of the oldest person in this document.\"\n",
+      "\n",
+      "Your Response:\n",
+      "{\n",
+      "    \"thought\": \"I will proceed step by step and use the following tools: `document_qa` to find the oldest person in the document, then `image_generator` to generate an image according to the answer.\",\n",
+      "    \"action\": {\n",
+      "        \"tool_name\": \"document_qa\",\n",
+      "        \"tool_params\": [{\"name\": \"document\"}, {\"value\": \"document.pdf\"}, {\"name\": \"question\"}, {\"value\": \"Who is the oldest person mentioned?\"}]\n",
+      "    },\n",
+      "    \"answer\": null\n",
+      "}\n",
+      "\n",
+      "Your Observation: \"The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland.\"\n",
+      "\n",
+      "Your Response:\n",
+      "{\n",
+      "    \"thought\": \"I will now generate an image showcasing the oldest person.\",\n",
+      "    \"action\": {\n",
+      "        \"tool_name\": \"image_generator\",\n",
+      "        \"tool_params\": [{\"name\": \"prompt\"}, {\"value\": \"A portrait of John Doe, a 55-year-old man living in Canada.\"}]\n",
+      "    },\n",
+      "    \"answer\": null\n",
+      "}\n",
+      "Your Observation: \"image.png\"\n",
+      "\n",
+      "{\n",
+      "    \"thought\": \"I will now return the generated image.\",\n",
+      "    \"action\": null,\n",
+      "    \"answer\": \"image.png\"\n",
+      "}\n",
+      "\n",
+      "---\n",
+      "Task: \"What is the result of the following operation: 5 + 3 + 1294.678?\"\n",
+      "\n",
+      "Your Response:\n",
+      "{\n",
+      "    \"thought\": \"I will use python code evaluator to compute the result of the operation and then return the final answer using the `final_answer` tool\",\n",
+      "    \"action\": {\n",
+      "        \"tool_name\": \"python_interpreter\",\n",
+      "        \"tool_params\": [{\"name\": \"code\"}, {\"value\": \"5 + 3 + 1294.678\"}]\n",
+      "    },\n",
+      "    \"answer\": null\n",
+      "}\n",
+      "Your Observation: 1302.678\n",
+      "\n",
+      "{\n",
+      "    \"thought\": \"Now that I know the result, I will now return it.\",\n",
+      "    \"action\": null,\n",
+      "    \"answer\": 1302.678\n",
+      "}\n",
+      "\n",
+      "---\n",
+      "Task: \"Which city has the highest population , Guangzhou or Shanghai?\"\n",
+      "\n",
+      "Your Response:\n",
+      "{\n",
+      "    \"thought\": \"I need to get the populations for both cities and compare them: I will use the tool `search` to get the population of both cities.\",\n",
+      "    \"action\": {\n",
+      "        \"tool_name\": \"search\",\n",
+      "        \"tool_params\": [{\"name\": \"query\"}, {\"value\": \"Population Guangzhou\"}]\n",
+      "    },\n",
+      "    \"answer\": null\n",
+      "}\n",
+      "Your Observation: ['Guangzhou has a population of 15 million inhabitants as of 2021.']\n",
+      "\n",
+      "Your Response:\n",
+      "{\n",
+      "    \"thought\": \"Now let's get the population of Shanghai using the tool 'search'.\",\n",
+      "    \"action\": {\n",
+      "        \"tool_name\": \"search\",\n",
+      "        \"tool_params\": [{\"name\": \"query\"}, {\"value\": \"Population Shanghai\"}]\n",
+      "    },\n",
+      "    \"answer\": null\n",
+      "}\n",
+      "Your Observation: \"26 million (2019)\"\n",
+      "\n",
+      "Your Response:\n",
+      "{\n",
+      "    \"thought\": \"Now I know that Shanghai has a larger population. Let's return the result.\",\n",
+      "    \"action\": null,\n",
+      "    \"answer\": \"Shanghai\"\n",
+      "}\n",
+      "\n",
+      "Above example were using notional tools that might not exist for you. You only have access to these tools:\n",
+      "- is_document_in_local_cache: {'name': 'is_document_in_local_cache', 'description': 'Verify if a Docling document is already converted and in the local cache.', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None)]}\n",
+      "- convert_pdf_document_into_docling_document: {'name': 'convert_pdf_document_into_docling_document', 'description': \"Convert a PDF document from a URL or local path and store in local cache.\\n\\n    This tool takes a PDF document's URL or local file path, converts it using\\n    Docling's DocumentConverter and stores the resulting Docling document in a\\n    local cache. It returns an output with a boolean set to True along with the\\n    document's unique cache key. If the document was already in the local cache,\\n    the conversion is skipped and the output boolean is set to False.\\n    \", 'parameters': [Parameter(description='The URL or local file path to the PDF document.', name='source', parameter_type='string', required=True, default=None)]}\n",
+      "- create_new_docling_document: {'name': 'create_new_docling_document', 'description': 'Create a new Docling document from a provided prompt string.\\n\\n    This function generates a new document in the local document cache with the\\n    provided prompt text. The document is assigned a unique key derived from an MD5\\n    hash of the prompt text.\\n    ', 'parameters': [Parameter(description='The prompt text to include in the new document.', name='prompt', parameter_type='string', required=True, default=None)]}\n",
+      "- export_docling_document_to_markdown: {'name': 'export_docling_document_to_markdown', 'description': 'Export a document from the local document cache to markdown format.\\n\\n    This tool converts a Docling document that exists in the local cache into\\n    a markdown formatted string, which can be used for display or further processing.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None)]}\n",
+      "- save_docling_document: {'name': 'save_docling_document', 'description': 'Save a document from the local document cache to disk in both markdown and JSON formats.\\n\\n    This tool takes a document that exists in the local cache and saves it to the specified\\n    cache directory with filenames based on the document key. Both markdown and JSON versions\\n    of the document are saved.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None)]}\n",
+      "- add_title_to_docling_document: {'name': 'add_title_to_docling_document', 'description': 'Add or update the title of a document in the local document cache.\\n\\n    This tool modifies an existing document that has already been processed\\n    and stored in the local cache. It requires that the document already exists\\n    in the cache before a title can be added.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='The title text to add or update to the document.', name='title', parameter_type='string', required=True, default=None)]}\n",
+      "- add_section_heading_to_docling_document: {'name': 'add_section_heading_to_docling_document', 'description': 'Add a section heading to an existing document in the local document cache.\\n\\n    This tool inserts a section heading with the specified heading text and level\\n    into a document that has already been processed and stored in the local cache.\\n    Section levels typically represent heading hierarchy (e.g., 1 for H1, 2 for H2).\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='The text to use for the section heading.', name='section_heading', parameter_type='string', required=True, default=None), Parameter(description='The level of the heading, starting from 1, where 1 is the highest level.', name='section_level', parameter_type='integer', required=True, default=None)]}\n",
+      "- add_paragraph_to_docling_document: {'name': 'add_paragraph_to_docling_document', 'description': 'Add a paragraph of text to an existing document in the local document cache.\\n\\n    This tool inserts a new paragraph under the specified section header and level\\n    into a document that has already been processed and stored in the cache.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='The text content to add as a paragraph.', name='paragraph', parameter_type='string', required=True, default=None)]}\n",
+      "- open_list_in_docling_document: {'name': 'open_list_in_docling_document', 'description': \"Open a new list group in an existing document in the local document cache.\\n\\n    This tool creates a new list structure within a document that has already been\\n    processed and stored in the local cache. It requires that the document already exists\\n    and that there is at least one item in the document's stack cache.\\n    \", 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None)]}\n",
+      "- close_list_in_docling_document: {'name': 'close_list_in_docling_document', 'description': \"Closes a list group in an existing document in the local document cache.\\n\\n    This tool closes a previously opened list structure within a document.\\n    It requires that the document exists and that there is more than one item\\n    in the document's stack cache.\\n    \", 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None)]}\n",
+      "- add_list_items_to_list_in_docling_document: {'name': 'add_list_items_to_list_in_docling_document', 'description': \"Add list items to an open list in an existing document in the local document cache.\\n\\n    This tool inserts new list items with the specified text and marker into an\\n    open list within a document. It requires that the document exists and that\\n    there is at least one item in the document's stack cache.\\n    \", 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='A list of list_item_text and list_marker_text items.', name='list_items', parameter_type='array', required=True, default=None)]}\n",
+      "- add_table_in_html_format_to_docling_document: {'name': 'add_table_in_html_format_to_docling_document', 'description': 'Add an HTML-formatted table to an existing document in the local document cache.\\n\\n    This tool parses the provided HTML table string, converts it to a structured table\\n    representation, and adds it to the specified document. It also supports optional\\n    captions and footnotes for the table.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='The HTML string representation of the table to add.', name='html_table', parameter_type='string', required=True, default=None), Parameter(description='A list of caption strings to associate with the table..', name='table_captions', parameter_type='string', required=True, default=None), Parameter(description='A list of footnote strings to associate with the table.', name='table_footnotes', parameter_type='string', required=True, default=None)]}\n",
+      "- get_overview_of_document_anchors: {'name': 'get_overview_of_document_anchors', 'description': \"Retrieve a structured overview of a document from the local document cache.\\n\\n    This tool returns a text representation of the Docling document's structure,\\n    showing the hierarchy and types of elements within the document. Each line in the\\n    output includes the document anchor reference and item label.\\n    \", 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None)]}\n",
+      "- get_text_of_document_item_at_anchor: {'name': 'get_text_of_document_item_at_anchor', 'description': 'Retrieve the text content of a specific document item identified by its anchor.\\n\\n    This tool extracts the text from a Docling document item at the specified anchor\\n    location within a document that exists in the local document cache.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='The anchor reference that identifies the specific item within the document.', name='document_anchor', parameter_type='string', required=True, default=None)]}\n",
+      "- update_text_of_document_item_at_anchor: {'name': 'update_text_of_document_item_at_anchor', 'description': 'Update the text content of a specific document item identified by its anchor.\\n\\n    This tool modifies the text of an existing document item at the specified anchor\\n    location within a document that exists in the local document cache. It returns\\n    True if the update was successful.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='The anchor reference that identifies the specific item within the document.', name='document_anchor', parameter_type='string', required=True, default=None), Parameter(description='The new text content to replace the existing content.', name='updated_text', parameter_type='string', required=True, default=None)]}\n",
+      "- delete_document_items_at_anchors: {'name': 'delete_document_items_at_anchors', 'description': 'Delete multiple document items identified by their anchors.\\n\\n    This tool removes specified items from a Docling document that exists in the local\\n    document cache, based on their anchor references. It returns True if the all the\\n    items were successfully removed.\\n    ', 'parameters': [Parameter(description='The unique identifier of the document in the local cache.', name='document_key', parameter_type='string', required=True, default=None), Parameter(description='A list of anchor references identifying the items to be deleted from the document.', name='document_anchors', parameter_type='array', required=True, default=None)]}\n",
+      "\n",
+      "Here are the rules you should always follow to solve your task:\n",
+      "1. ALWAYS answer in the JSON format with keys \"thought\", \"action\", \"answer\", else you will fail. \n",
+      "2. Always use the right arguments for the tools. Never use variable names in the 'tool_params' field, use the value instead.\n",
+      "3. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself.\n",
+      "4. Never re-do a tool call that you previously did with the exact same parameters.\n",
+      "5. Observations will be provided to you, no need to generate them\n",
+      "\n",
+      "Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ReAct instructions\n",
+    "from llama_stack_client.lib.agents.agent import AgentUtils\n",
+    "from llama_stack_client.lib.agents.react.agent import get_default_react_instructions\n",
+    "\n",
+    "client_tools = AgentUtils.get_client_tools([\"mcp::docling\"])\n",
+    "instructions = get_default_react_instructions(client, [\"mcp::docling\"], client_tools)\n",
+    "print(instructions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "771c451f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: GET http://localhost:8321/v1/tools?toolgroup_id=mcp%3A%3Adocling \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: GET http://localhost:8321/v1/tools?toolgroup_id=mcp%3A%3Adocling \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session/b9233abc-1f44-4850-a308-be5381c4f0d9/turn \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "==================================================\n",
+      "👤 User Query:\n",
+      "\u001b[36mI want you to create a new Docling document on Quantum Computing.\n",
+      "    To do this, you will create a document first by invoking `create_new_docling_document` with Quantum Computing as prompt.\n",
+      "    Add a title and 3 paragraphs describing the topic, one by one.\n",
+      "    At the end of the writing, you must save the document by calling `save_docling_document` and return me the filepath of\n",
+      "    the saved document in markdown format.\n",
+      "    \u001b[0m\n",
+      "==================================================\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/tool-runtime/invoke \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session/b9233abc-1f44-4850-a308-be5381c4f0d9/turn/606cdfb8-3c94-4822-a016-c134de43b2b2/resume \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/tool-runtime/invoke \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session/b9233abc-1f44-4850-a308-be5381c4f0d9/turn/606cdfb8-3c94-4822-a016-c134de43b2b2/resume \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/tool-runtime/invoke \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session/b9233abc-1f44-4850-a308-be5381c4f0d9/turn/606cdfb8-3c94-4822-a016-c134de43b2b2/resume \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/tool-runtime/invoke \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session/b9233abc-1f44-4850-a308-be5381c4f0d9/turn/606cdfb8-3c94-4822-a016-c134de43b2b2/resume \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/tool-runtime/invoke \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session/b9233abc-1f44-4850-a308-be5381c4f0d9/turn/606cdfb8-3c94-4822-a016-c134de43b2b2/resume \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/tool-runtime/invoke \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST http://localhost:8321/v1/agents/06eb6a2d-ca0b-473f-be27-75240d1e659a/session/b9233abc-1f44-4850-a308-be5381c4f0d9/turn/606cdfb8-3c94-4822-a016-c134de43b2b2/resume \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 1: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35m{\n",
+      "  \"thought\": \"I want to create a new Docling document on Quantum Computing\",\n",
+      "  \"action\": {\n",
+      "    \"tool_name\": \"create_new_docling_document\",\n",
+      "    \"tool_params\": [\n",
+      "      {\"name\": \"prompt\", \"value\": \"Quantum Computing\"}\n",
+      "    ]\n",
+      "  },\n",
+      "  \"answer\": null\n",
+      "}\n",
+      "\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 2: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\",\\n  \"prompt\": \"Quantum Computing\"\\n}'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"font-weight: bold\">]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\",\\n  \"prompt\": \"Quantum Computing\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m)\u001b[0m\n",
+       "\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 3: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35m{\n",
+      "  \"thought\": \"I want to add a title to the document\",\n",
+      "  \"action\": {\n",
+      "    \"tool_name\": \"add_paragraph_to_docling_document\",\n",
+      "    \"tool_params\": [\n",
+      "      {\"name\": \"document_key\", \"value\": \"6f1933d17fb2cce1d2a578e40315f711\"},\n",
+      "      {\"name\": \"paragraph\", \"value\": \"Quantum Computing: An Introduction\"}\n",
+      "    ]\n",
+      "  },\n",
+      "  \"answer\": null\n",
+      "}\n",
+      "\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 4: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n}'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span><span style=\"font-weight: bold\">)]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m, \u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\u001b[1m)\u001b[0m\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 5: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35m{\n",
+      "  \"thought\": \"I want to add the first paragraph to the document\",\n",
+      "  \"action\": {\n",
+      "    \"tool_name\": \"add_paragraph_to_docling_document\",\n",
+      "    \"tool_params\": [\n",
+      "      {\"name\": \"document_key\", \"value\": \"6f1933d17fb2cce1d2a578e40315f711\"},\n",
+      "      {\"name\": \"paragraph\", \"value\": \"Quantum Computing is a branch of physics that studies the behavior of matter and energy at an atomic and subatomic level.\"}\n",
+      "    ]\n",
+      "  },\n",
+      "  \"answer\": null\n",
+      "}\n",
+      "\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 6: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n}'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span><span style=\"font-weight: bold\">)]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m, \u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\u001b[1m)\u001b[0m\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 7: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35m{\n",
+      "  \"thought\": \"I want to add the second paragraph to the document\",\n",
+      "  \"action\": {\n",
+      "    \"tool_name\": \"add_paragraph_to_docling_document\",\n",
+      "    \"tool_params\": [\n",
+      "      {\"name\": \"document_key\", \"value\": \"6f1933d17fb2cce1d2a578e40315f711\"},\n",
+      "      {\"name\": \"paragraph\", \"value\": \"Quantum Computing is a branch of physics that studies the behavior of matter and energy at an atomic and subatomic level. It has the potential to revolutionize many fields, including computer science, chemistry, and materials science.\"}\n",
+      "    ]\n",
+      "  },\n",
+      "  \"answer\": null\n",
+      "}\n",
+      "\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 8: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n}'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span><span style=\"font-weight: bold\">)]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m, \u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\u001b[1m)\u001b[0m\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 9: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35m{\n",
+      "  \"thought\": \"I want to add a title and three paragraphs to the document\",\n",
+      "  \"action\": {\n",
+      "    \"tool_name\": \"add_paragraph_to_docling_document\",\n",
+      "    \"tool_params\": [\n",
+      "      {\"name\": \"document_key\", \"value\": \"6f1933d17fb2cce1d2a578e40315f711\"},\n",
+      "      {\"name\": \"paragraph\", \"value\": \"Quantum Computing: An Introduction\"}\n",
+      "    ]\n",
+      "  },\n",
+      "  \"answer\": null\n",
+      "}\n",
+      "\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 10: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n}'</span>, <span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span><span style=\"font-weight: bold\">)]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"document_key\": \"6f1933d17fb2cce1d2a578e40315f711\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m, \u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\u001b[1m)\u001b[0m\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 11: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35m{\n",
+      "  \"thought\": \"I want to save the document\",\n",
+      "  \"action\": {\n",
+      "    \"tool_name\": \"save_docling_document\",\n",
+      "    \"tool_params\": [\n",
+      "      {\"name\": \"document_key\", \"value\": \"6f1933d17fb2cce1d2a578e40315f711\"}\n",
+      "    ]\n",
+      "  },\n",
+      "  \"answer\": null\n",
+      "}\n",
+      "\u001b[0m\n",
+      "\n",
+      "---------- 📍 Step 12: ToolExecutionStep ----------\n",
+      "🔧 Executing tool...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">[</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">TextContentItem</span><span style=\"font-weight: bold\">(</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">text</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'{\\n  \"md_file\": \"/Users/ceb/git/docling-mcp/_cache/6f1933d17fb2cce1d2a578e40315f711.md\",\\n  \"json_file\": \"/Users/ceb/git/docling-mcp/_cache/6f1933d17fb2cce1d2a578e40315f711.json\"\\n}'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'text'</span>\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   </span><span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"font-weight: bold\">]</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1;35mTextContentItem\u001b[0m\u001b[1m(\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtext\u001b[0m=\u001b[32m'\u001b[0m\u001b[32m{\u001b[0m\u001b[32m\\n  \"md_file\": \"/Users/ceb/git/docling-mcp/_cache/6f1933d17fb2cce1d2a578e40315f711.md\",\\n  \"json_file\": \"/Users/ceb/git/docling-mcp/_cache/6f1933d17fb2cce1d2a578e40315f711.json\"\\n\u001b[0m\u001b[32m}\u001b[0m\u001b[32m'\u001b[0m,\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[33mtype\u001b[0m=\u001b[32m'text'\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m)\u001b[0m\n",
+       "\u001b[1m]\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "---------- 📍 Step 13: InferenceStep ----------\n",
+      "🤖 Model Response:\n",
+      "\u001b[35m{\n",
+      "  \"thought\": \"I want to save the document\",\n",
+      "  \"action\": {\n",
+      "    \"tool_name\": \"save_docling_document\",\n",
+      "    \"tool_params\": [\n",
+      "      {\"name\": \"document_key\", \"value\": \"6f1933d17fb2cce1d2a578e40315f711\"}\n",
+      "    ]\n",
+      "  },\n",
+      "  \"answer\": \"/Users/ceb/git/docling-mcp/_cache/6f1933d17fb2cce1d2a578e40315f711.md\"\n",
+      "}\n",
+      "\u001b[0m\n",
+      "========== Query processing completed ========== \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "agent = ReActAgent(\n",
+    "    client=client,\n",
+    "    model=settings.inference_model,\n",
+    "    tools=[\"mcp::docling\"],\n",
+    "    response_format={\n",
+    "        \"type\": \"json_schema\",\n",
+    "        \"json_schema\": ReActOutput.model_json_schema(),\n",
+    "    },\n",
+    "    sampling_params=sampling_params,\n",
+    ")\n",
+    "\n",
+    "user_prompts = [\n",
+    "    \"\"\"I want you to create a new Docling document on Quantum Computing.\n",
+    "    To do this, you will create a document first by invoking `create_new_docling_document` with Quantum Computing as prompt.\n",
+    "    Add a title and 3 paragraphs describing the topic, one by one.\n",
+    "    At the end of the writing, you must save the document by calling `save_docling_document` and return me the filepath of\n",
+    "    the saved document in markdown format.\n",
+    "    \"\"\"\n",
+    "]\n",
+    "\n",
+    "session_id = agent.create_session(f\"docling-session_{uuid.uuid4()}\")\n",
+    "for prompt in user_prompts:\n",
+    "    print(\"\\n\" + \"=\" * 50)\n",
+    "    user_printer(prompt)\n",
+    "    print(\"=\" * 50)\n",
+    "    response = agent.create_turn(\n",
+    "        messages=[\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": prompt,\n",
+    "            }\n",
+    "        ],\n",
+    "        session_id=session_id,\n",
+    "        stream=settings.stream,\n",
+    "    )\n",
+    "    if settings.stream:\n",
+    "        for log in EventLogger().log(response):\n",
+    "            log.print()\n",
+    "    else:\n",
+    "        step_printer(\n",
+    "            response.steps\n",
+    "        )  # print the steps of an agent's response in a formatted way."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/llama-stack/requirements.txt
+++ b/examples/llama-stack/requirements.txt
@@ -1,0 +1,4 @@
+ipykernel~=6.29
+notebook~=7.4
+llama-stack-client~=0.2.14
+mcp~=1.10

--- a/examples/llama-stack/src/utils.py
+++ b/examples/llama-stack/src/utils.py
@@ -1,0 +1,47 @@
+"""Utility functions for examples of building agents with Docling MCP and Llama Stack.
+
+This module takes some implementations from [Llama Stack Demos](https://github.com/opendatahub-io/llama-stack-demos/tree/main/demos/rag_agentic).
+"""
+
+import json
+from json import JSONDecodeError
+
+from rich.pretty import pprint
+from termcolor import cprint
+
+
+def step_printer(steps):
+    """
+    Print the steps of an agent's response in a formatted way.
+    Note: stream need to be set to False to use this function.
+    Args:
+    steps: List of steps from an agent's response.
+    """
+    for i, step in enumerate(steps):
+        step_type = type(step).__name__
+        print("\n" + "-" * 10, f"📍 Step {i + 1}: {step_type}", "-" * 10)
+        if step_type == "ToolExecutionStep":
+            print("🔧 Executing tool...")
+            try:
+                pprint(json.loads(step.tool_responses[0].content))
+            except (TypeError, JSONDecodeError):
+                # tool response is not a valid JSON object
+                pprint(step.tool_responses[0].content)
+        else:
+            if step.api_model_response.content:
+                print("🤖 Model Response:")
+                cprint(f"{step.api_model_response.content}\n", "magenta")
+            elif step.api_model_response.tool_calls:
+                tool_call = step.api_model_response.tool_calls[0]
+                print("🛠️ Tool call Generated:")
+                cprint(
+                    f"Tool call: {tool_call.tool_name}, "
+                    f"Arguments: {json.loads(tool_call.arguments_json)}",
+                    "magenta",
+                )
+    print("=" * 10, "Query processing completed", "=" * 10, "\n")
+
+
+def user_printer(query: str) -> None:
+    print("👤 User Query:")
+    cprint(query, "cyan")


### PR DESCRIPTION
This PR provides a programmatic example for using Docling MCP with Llama Stack client.
A notebook illustrates the usage of Docling tools with single step prompts and a ReAct prompt.