### PR TITLE
fix: add max_size truncating the exported markdown

### DIFF
--- a/docling_mcp/tools/generation.py
+++ b/docling_mcp/tools/generation.py
@@ -89,6 +89,9 @@ def export_docling_document_to_markdown(
         str,
         Field(description="The unique identifier of the document in the local cache."),
     ],
+    max_size: Annotated[
+        int | None, Field(description="The maximum number of characters to return.")
+    ] = None,
 ) -> ExportDocumentMarkdownOutput:
     """Export a document from the local document cache to markdown format.
 
@@ -102,6 +105,8 @@ def export_docling_document_to_markdown(
         )
 
     markdown = local_document_cache[document_key].export_to_markdown()
+    if max_size:
+        markdown = markdown[:max_size]
 
     return ExportDocumentMarkdownOutput(document_key, markdown)
 


### PR DESCRIPTION
No impact on current examples, but it allows prompts like

> Export the first 1000 characters of the document to markdown.

I've seen also reasoning loop like:
1. Model request export to markdown
2. It goes out of maximum context window
3. Retries automatically with smaller truncation

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
