### PR TITLE
fix: remove complex metadata for openai responses api support

### DIFF
--- a/docling_mcp/tools/llama_stack/rag.py
+++ b/docling_mcp/tools/llama_stack/rag.py
@@ -81,7 +81,7 @@ def insert_document_to_vectordb(
             "chunk_id": chunk_id,
             "token_count": token_count,
             # "metadata_token_count": 0,
-            "doc_items": [item.self_ref for item in meta.doc_items],
+            "doc_items": ",".join([item.self_ref for item in meta.doc_items]),
         }
         chunk_metadata: ChunkChunkMetadata = {
             "document_id": doc_id,


### PR DESCRIPTION
The retrieval logic in LLS fails if we push non-trivial metadata, so we concatenate the doc_items into a comma-separated list.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
