### PR TITLE
fix: allow non-localhost connections by configuring trusted_hosts

### DIFF
--- a/docling_mcp/servers/mcp_server.py
+++ b/docling_mcp/servers/mcp_server.py
@@ -80,6 +80,15 @@ def main(
     logger.info("starting up Docling MCP-server ...")
     mcp.settings.host = host
     mcp.settings.port = port
+    
+    # Configure trusted hosts to support both hostname and IP address connections
+    # This fixes issue #89: 421 error when accessing via IP instead of localhost
+    # When host is "0.0.0.0", we need to allow any valid connection
+    if host == "0.0.0.0":
+        mcp.settings.uvicorn_kwargs = {
+            "trusted_hosts": ["*"],
+        }
+    
     mcp.run(transport=transport.value)
 
 


### PR DESCRIPTION
Fixes #89: 421 Misdirected Request error when accessing MCP server via IP address

When the server is configured with --host 0.0.0.0 (which allows connections from any interface), uvicorn's Host header validation would reject requests made via IP address because the trusted_hosts list wasn't configured to accept them.

This fix adds uvicorn_kwargs configuration to allow any valid Host header when the server is bound to all interfaces (0.0.0.0), enabling access from both localhost and IP addresses in Kubernetes and other containerized environments.

## Testing
- Server started with --host 0.0.0.0 --port 8000
- ✅ Connections via localhost work
- ✅ Connections via IP address (172.16.x.x) now work  
- ✅ Custom Host headers are allowed
