### PR TITLE
fix: clarify missing remote configuration error

### DIFF
--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -27,8 +27,11 @@ class RemoteDocumentConverter:
             raise ValueError(
                 "DOCLING_MCP_SERVICE_URL is not set but "
                 "DOCLING_MCP_CONVERSION_MODE=remote. "
-                "Set it via environment variable or in a .env file. "
-                "See .env.example for all available configuration variables."
+                "To fix this, either:\n"
+                "  - Remote: set DOCLING_MCP_SERVICE_URL (env var or .env) to a "
+                "Docling Serve endpoint, or\n"
+                "  - Local: set DOCLING_MCP_CONVERSION_MODE=local and install the "
+                "local extra: pip install 'docling-mcp[local]'."
             )
 
         # DoclingServiceClient requires api_key to be str, not Optional[str]

--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -29,8 +29,11 @@ class RemoteDocumentConverter:
             raise ValueError(
                 "DOCLING_MCP_SERVICE_URL is not set but "
                 "DOCLING_MCP_CONVERSION_MODE=remote. "
-                "Set it via environment variable or in a .env file. "
-                "See .env.example for all available configuration variables."
+                "To fix this, either:\n"
+                "  - Remote: set DOCLING_MCP_SERVICE_URL (env var or .env) to a "
+                "Docling Serve endpoint, or\n"
+                "  - Local: set DOCLING_MCP_CONVERSION_MODE=local and install the "
+                "local extra: pip install 'docling-mcp[local]'."
             )
 
         # DoclingServiceClient requires api_key to be str, not Optional[str]

--- a/tests/test_remote_converter.py
+++ b/tests/test_remote_converter.py
@@ -14,11 +14,18 @@ class TestRemoteDocumentConverter:
 
     @patch("docling_mcp.tools.converters.remote.settings")
     def test_init_without_service_url_raises_error(self, mock_settings: Any) -> None:
-        """Test that initialization fails without service URL."""
+        """Test that the error names both the remote and local remedies."""
         mock_settings.service_url = None
 
-        with pytest.raises(ValueError, match="DOCLING_MCP_SERVICE_URL is not set"):
+        with pytest.raises(
+            ValueError, match="DOCLING_MCP_SERVICE_URL is not set"
+        ) as exc_info:
             RemoteDocumentConverter()
+
+        message = str(exc_info.value)
+        assert "Remote: set DOCLING_MCP_SERVICE_URL" in message
+        assert "DOCLING_MCP_CONVERSION_MODE=local" in message
+        assert "docling-mcp[local]" in message
 
     @patch("docling_mcp.tools.converters.remote.DoclingServiceClient")
     @patch("docling_mcp.tools.converters.remote.settings")


### PR DESCRIPTION
## Description

Running the MCP server in the default remote mode without `DOCLING_MCP_SERVICE_URL` raises a `ValueError`. The error now names both supported remedies: configure the remote service, or switch to local conversion and install `docling-mcp[local]`.

The remote default remains unchanged.

## Changes

- Update the missing-service error with remote and local remedies using the current `DOCLING_MCP_*` settings.
- Cover both remedies in the existing converter test.

The original README addition was dropped after the rebase because current `main` already documents remote and local configuration.

Resolves #103
