### PR TITLE
feat: add Ollama-backed granite-docling pipeline option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ DOCLING_MCP_DO_OCR=true
 DOCLING_MCP_DO_TABLE_STRUCTURE=true
 
 
+# ── Local VLM pipeline ───────────────────────────────────────
+DOCLING_MCP_USE_VLM=false
+DOCLING_MCP_VLM_HOST=http://localhost:11434
+
+
 # ── LlamaIndex RAG tool (tool group: llama-index-rag) ────────
 DOCLING_MCP_LI_API_BASE=http://127.0.0.1:1234/v1
 DOCLING_MCP_LI_API_KEY=none

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Then configure your environment:
 export DOCLING_CONVERSION_MODE=local
 ```
 
+By default, local mode uses Docling's standard OCR/layout pipeline. To use the
+VLM pipeline instead (e.g. [granite-docling](https://huggingface.co/ibm-granite/granite-docling-258M)
+served by a local [Ollama](https://ollama.com) instance), set:
+```bash
+export DOCLING_MCP_USE_VLM=true
+export DOCLING_MCP_VLM_HOST=http://localhost:11434
+```
+
 ### Hybrid Mode (Best of Both)
 
 Install with local support and enable automatic fallback:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ Then configure your environment:
 export DOCLING_MCP_CONVERSION_MODE=local
 ```
 
+By default, local mode uses Docling's standard OCR/layout pipeline. To use the
+VLM pipeline instead (e.g. [granite-docling](https://huggingface.co/ibm-granite/granite-docling-258M)
+served by a local [Ollama](https://ollama.com) instance), set:
+
+```bash
+export DOCLING_MCP_USE_VLM=true
+export DOCLING_MCP_VLM_HOST=http://localhost:11434
+```
+
 ### Hybrid Mode (Best of Both)
 
 Install with local support and enable automatic fallback:
@@ -128,6 +137,13 @@ your MCP client config. Copy [`.env.example`](.env.example) as a starting point.
 | `DOCLING_MCP_IMAGES_SCALE` | `1.0` | Image scale factor (increase to avoid tensor padding errors) |
 | `DOCLING_MCP_DO_OCR` | `true` | Run OCR pipeline |
 | `DOCLING_MCP_DO_TABLE_STRUCTURE` | `true` | Detect table structure |
+
+### Local VLM pipeline
+
+| Variable | Default | Description |
+|---|---|---|
+| `DOCLING_MCP_USE_VLM` | `false` | Use the `granite_docling` VLM pipeline through Ollama |
+| `DOCLING_MCP_VLM_HOST` | `http://localhost:11434` | Base URL of the Ollama server |
 
 ### LlamaIndex RAG (`--tools llama-index-rag`)
 

--- a/docling_mcp/settings/conversion.py
+++ b/docling_mcp/settings/conversion.py
@@ -17,5 +17,10 @@ class ConversionSettings(BaseSettings):
     do_ocr: bool = True
     do_table_structure: bool = True
 
+    # Use the VLM pipeline (e.g. granite-docling via a local Ollama instance)
+    # instead of the standard OCR/layout pipeline.
+    use_vlm: bool = False
+    vlm_host: str = "http://localhost:11434"
+
 
 settings = ConversionSettings()

--- a/docling_mcp/settings/service_client.py
+++ b/docling_mcp/settings/service_client.py
@@ -47,6 +47,8 @@ class ServiceClientSettings(BaseSettings):
     images_scale: float = 1.0
     do_ocr: bool = True
     do_table_structure: bool = True
+    use_vlm: bool = False
+    vlm_host: str = "http://localhost:11434"
 
     def model_post_init(self, __context: object) -> None:
         """Warn when deprecated (pre-refactor) environment variable names are set."""

--- a/docling_mcp/tools/converters/local.py
+++ b/docling_mcp/tools/converters/local.py
@@ -15,12 +15,20 @@ from .base import ConversionOutput
 # Import DocumentConverter only if available
 try:
     from docling.datamodel.base_models import InputFormat
-    from docling.datamodel.pipeline_options import PdfPipelineOptions
+    from docling.datamodel.pipeline_options import (
+        PdfPipelineOptions,
+        VlmPipelineOptions,
+    )
+    from docling.datamodel.pipeline_options_vlm_model import (
+        ApiVlmOptions,
+        ResponseFormat,
+    )
     from docling.document_converter import (
         DocumentConverter,
         FormatOption,
         PdfFormatOption,
     )
+    from docling.pipeline.vlm_pipeline import VlmPipeline
 
     LOCAL_CONVERSION_AVAILABLE = True
 except ImportError:
@@ -47,15 +55,36 @@ class LocalDocumentConverter:
         if self._converter is not None:
             return self._converter
 
-        pipeline_options = PdfPipelineOptions()
-        pipeline_options.generate_page_images = settings.keep_images
-        pipeline_options.do_ocr = settings.do_ocr
-        pipeline_options.do_table_structure = settings.do_table_structure
+        format_options: dict[InputFormat, FormatOption]
+        if settings.use_vlm:
+            vlm_pipeline_options = VlmPipelineOptions(
+                enable_remote_services=True,
+                vlm_options=ApiVlmOptions(
+                    url=f"{settings.vlm_host}/v1/chat/completions",
+                    params={"model": "ibm/granite-docling:258m"},
+                    prompt="Convert this page to docling.",
+                    response_format=ResponseFormat.DOCTAGS,
+                    stop_strings=["</doctag>", "<|end_of_text|>"],
+                ),
+            )
+            format_options = {
+                InputFormat.PDF: PdfFormatOption(
+                    pipeline_options=vlm_pipeline_options, pipeline_cls=VlmPipeline
+                ),
+                InputFormat.IMAGE: PdfFormatOption(
+                    pipeline_options=vlm_pipeline_options, pipeline_cls=VlmPipeline
+                ),
+            }
+        else:
+            pipeline_options = PdfPipelineOptions()
+            pipeline_options.generate_page_images = settings.keep_images
+            pipeline_options.do_ocr = settings.do_ocr
+            pipeline_options.do_table_structure = settings.do_table_structure
 
-        format_options: dict[InputFormat, FormatOption] = {
-            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
-            InputFormat.IMAGE: PdfFormatOption(pipeline_options=pipeline_options),
-        }
+            format_options = {
+                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+                InputFormat.IMAGE: PdfFormatOption(pipeline_options=pipeline_options),
+            }
 
         logger.info(f"Creating DocumentConverter with options: {format_options}")
         self._converter = DocumentConverter(format_options=format_options)

--- a/docling_mcp/tools/converters/local.py
+++ b/docling_mcp/tools/converters/local.py
@@ -15,12 +15,20 @@ from .base import ConversionOutput
 # Import DocumentConverter only if available
 try:
     from docling.datamodel.base_models import InputFormat
-    from docling.datamodel.pipeline_options import PdfPipelineOptions
+    from docling.datamodel.pipeline_options import (
+        PdfPipelineOptions,
+        VlmConvertOptions,
+        VlmPipelineOptions,
+    )
+    from docling.datamodel.vlm_engine_options import ApiVlmEngineOptions
     from docling.document_converter import (
         DocumentConverter,
         FormatOption,
+        ImageFormatOption,
         PdfFormatOption,
     )
+    from docling.models.inference_engines.vlm import VlmEngineType
+    from docling.pipeline.vlm_pipeline import VlmPipeline
 
     LOCAL_CONVERSION_AVAILABLE = True
 except ImportError:
@@ -47,16 +55,45 @@ class LocalDocumentConverter:
         if self._converter is not None:
             return self._converter
 
-        pipeline_options = PdfPipelineOptions()
-        pipeline_options.generate_page_images = settings.keep_images
-        pipeline_options.images_scale = settings.images_scale
-        pipeline_options.do_ocr = settings.do_ocr
-        pipeline_options.do_table_structure = settings.do_table_structure
+        format_options: dict[InputFormat, FormatOption]
+        if settings.use_vlm:
+            engine_options = ApiVlmEngineOptions.model_validate(
+                {
+                    "engine_type": VlmEngineType.API_OLLAMA,
+                    "url": f"{settings.vlm_host.rstrip('/')}/v1/chat/completions",
+                }
+            )
+            vlm_pipeline_options = VlmPipelineOptions(
+                enable_remote_services=True,
+                vlm_options=VlmConvertOptions.from_preset(
+                    "granite_docling", engine_options=engine_options
+                ),
+            )
+            pdf_format_option = PdfFormatOption(
+                pipeline_options=vlm_pipeline_options,
+                pipeline_cls=VlmPipeline,
+            )
+            image_format_option = ImageFormatOption(
+                pipeline_options=vlm_pipeline_options,
+                pipeline_cls=VlmPipeline,
+            )
+            format_options = {
+                InputFormat.PDF: pdf_format_option,
+                InputFormat.IMAGE: image_format_option,
+            }
+        else:
+            pdf_pipeline_options = PdfPipelineOptions()
+            pdf_pipeline_options.generate_page_images = settings.keep_images
+            pdf_pipeline_options.images_scale = settings.images_scale
+            pdf_pipeline_options.do_ocr = settings.do_ocr
+            pdf_pipeline_options.do_table_structure = settings.do_table_structure
 
-        format_options: dict[InputFormat, FormatOption] = {
-            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
-            InputFormat.IMAGE: PdfFormatOption(pipeline_options=pipeline_options),
-        }
+            format_options = {
+                InputFormat.PDF: PdfFormatOption(pipeline_options=pdf_pipeline_options),
+                InputFormat.IMAGE: PdfFormatOption(
+                    pipeline_options=pdf_pipeline_options
+                ),
+            }
 
         logger.info(f"Creating DocumentConverter with options: {format_options}")
         self._converter = DocumentConverter(format_options=format_options)

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -40,7 +40,9 @@
         "DOCLING_FALLBACK_TO_LOCAL": "${user_config.fallback_to_local}",
         "DOCLING_MCP_KEEP_IMAGES": "${user_config.keep_images}",
         "DOCLING_MCP_DO_OCR": "${user_config.do_ocr}",
-        "DOCLING_MCP_DO_TABLE_STRUCTURE": "${user_config.do_table_structure}"
+        "DOCLING_MCP_DO_TABLE_STRUCTURE": "${user_config.do_table_structure}",
+        "DOCLING_MCP_USE_VLM": "${user_config.use_vlm}",
+        "DOCLING_MCP_VLM_HOST": "${user_config.vlm_host}"
       }
     }
   },
@@ -114,6 +116,20 @@
       "title": "Enable Table Structure",
       "description": "Enable table structure recognition (applies to local mode).",
       "default": true,
+      "required": false
+    },
+    "use_vlm": {
+      "type": "boolean",
+      "title": "Use VLM Pipeline",
+      "description": "Use the VLM pipeline (e.g. granite-docling via a local Ollama instance) instead of the standard OCR/layout pipeline (applies to local mode).",
+      "default": false,
+      "required": false
+    },
+    "vlm_host": {
+      "type": "string",
+      "title": "VLM Host",
+      "description": "Base URL of the Ollama (or other OpenAI-compatible) server to use when the VLM pipeline is enabled.",
+      "default": "http://localhost:11434",
       "required": false
     }
   },

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -42,7 +42,9 @@
         "DOCLING_MCP_KEEP_IMAGES": "${user_config.keep_images}",
         "DOCLING_MCP_IMAGES_SCALE": "${user_config.images_scale}",
         "DOCLING_MCP_DO_OCR": "${user_config.do_ocr}",
-        "DOCLING_MCP_DO_TABLE_STRUCTURE": "${user_config.do_table_structure}"
+        "DOCLING_MCP_DO_TABLE_STRUCTURE": "${user_config.do_table_structure}",
+        "DOCLING_MCP_USE_VLM": "${user_config.use_vlm}",
+        "DOCLING_MCP_VLM_HOST": "${user_config.vlm_host}"
       }
     }
   },
@@ -130,6 +132,20 @@
       "title": "Enable Table Structure",
       "description": "Enable table structure recognition.",
       "default": true,
+      "required": false
+    },
+    "use_vlm": {
+      "type": "boolean",
+      "title": "Use VLM Pipeline",
+      "description": "Use the VLM pipeline (e.g. granite-docling via a local Ollama instance) instead of the standard OCR/layout pipeline (applies to local mode).",
+      "default": false,
+      "required": false
+    },
+    "vlm_host": {
+      "type": "string",
+      "title": "Ollama Host",
+      "description": "Base URL of the Ollama server to use when the VLM pipeline is enabled.",
+      "default": "http://localhost:11434",
       "required": false
     }
   },

--- a/tests/test_local_converter.py
+++ b/tests/test_local_converter.py
@@ -5,6 +5,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import PdfPipelineOptions, VlmPipelineOptions
+from docling.datamodel.pipeline_options_vlm_model import ApiVlmOptions
+
 from docling_mcp.tools.converters.base import ConversionOutput
 from docling_mcp.tools.converters.local import (
     LocalDocumentConverter,
@@ -76,6 +80,41 @@ class TestLocalDocumentConverter:
         assert isinstance(result, ConversionOutput)
         assert result.from_cache is False
         assert result.document_key == cache_key
+
+    @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
+    @patch("docling_mcp.tools.converters.local.settings")
+    def test_get_converter_uses_pdf_pipeline_by_default(
+        self, mock_settings: Any
+    ) -> None:
+        """Test the default converter uses the standard PDF pipeline."""
+        mock_settings.use_vlm = False
+        mock_settings.keep_images = False
+        mock_settings.do_ocr = True
+        mock_settings.do_table_structure = True
+
+        converter = LocalDocumentConverter()
+        docling_converter = converter._get_converter()
+
+        pdf_option = docling_converter.format_to_options[InputFormat.PDF]
+        assert isinstance(pdf_option.pipeline_options, PdfPipelineOptions)
+
+    @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
+    @patch("docling_mcp.tools.converters.local.settings")
+    def test_get_converter_uses_vlm_pipeline_when_enabled(
+        self, mock_settings: Any
+    ) -> None:
+        """Test the converter switches to the VLM pipeline when use_vlm is set."""
+        mock_settings.use_vlm = True
+        mock_settings.vlm_host = "http://localhost:11434"
+
+        converter = LocalDocumentConverter()
+        docling_converter = converter._get_converter()
+
+        pdf_option = docling_converter.format_to_options[InputFormat.PDF]
+        assert isinstance(pdf_option.pipeline_options, VlmPipelineOptions)
+        vlm_options = pdf_option.pipeline_options.vlm_options
+        assert isinstance(vlm_options, ApiVlmOptions)
+        assert str(vlm_options.url) == "http://localhost:11434/v1/chat/completions"
 
     @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
     def test_is_available_when_installed(self) -> None:

--- a/tests/test_local_converter.py
+++ b/tests/test_local_converter.py
@@ -5,10 +5,46 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import (
+    PdfPipelineOptions,
+    VlmConvertOptions,
+    VlmPipelineOptions,
+)
+from docling.datamodel.vlm_engine_options import ApiVlmEngineOptions
+from docling.document_converter import ImageFormatOption, PdfFormatOption
+from docling.models.inference_engines.vlm import VlmEngineType
+from docling.pipeline.vlm_pipeline import VlmPipeline
+
+from docling_mcp.settings.service_client import ServiceClientSettings
 from docling_mcp.tools.converters.base import ConversionOutput
 from docling_mcp.tools.converters.local import (
     LocalDocumentConverter,
 )
+
+
+class TestVlmSettings:
+    def test_defaults_disable_vlm_with_local_ollama_host(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DOCLING_MCP_USE_VLM", raising=False)
+        monkeypatch.delenv("DOCLING_MCP_VLM_HOST", raising=False)
+
+        service_settings = ServiceClientSettings(_env_file=None)
+
+        assert service_settings.use_vlm is False
+        assert service_settings.vlm_host == "http://localhost:11434"
+
+    def test_reads_vlm_settings_from_prefixed_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DOCLING_MCP_USE_VLM", "true")
+        monkeypatch.setenv("DOCLING_MCP_VLM_HOST", "http://ollama.test:8080/")
+
+        service_settings = ServiceClientSettings(_env_file=None)
+
+        assert service_settings.use_vlm is True
+        assert service_settings.vlm_host == "http://ollama.test:8080/"
 
 
 class TestLocalDocumentConverter:
@@ -76,6 +112,94 @@ class TestLocalDocumentConverter:
         assert isinstance(result, ConversionOutput)
         assert result.from_cache is False
         assert result.document_key == cache_key
+
+    @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
+    def test_get_converter_preserves_pdf_pipeline_settings(self) -> None:
+        service_settings = ServiceClientSettings(
+            _env_file=None,
+            use_vlm=False,
+            keep_images=True,
+            images_scale=1.5,
+            do_ocr=False,
+            do_table_structure=False,
+        )
+
+        with patch("docling_mcp.tools.converters.local.settings", service_settings):
+            converter = LocalDocumentConverter()
+            docling_converter = converter._get_converter()
+
+        for input_format in (InputFormat.PDF, InputFormat.IMAGE):
+            pipeline_options = docling_converter.format_to_options[
+                input_format
+            ].pipeline_options
+            assert isinstance(pipeline_options, PdfPipelineOptions)
+            assert pipeline_options.generate_page_images is True
+            assert pipeline_options.images_scale == 1.5
+            assert pipeline_options.do_ocr is False
+            assert pipeline_options.do_table_structure is False
+
+    @pytest.mark.filterwarnings("error::DeprecationWarning")
+    @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
+    def test_get_converter_configures_granite_docling_vlm_pipeline(self) -> None:
+        service_settings = ServiceClientSettings(
+            _env_file=None,
+            use_vlm=True,
+            vlm_host="http://localhost:11434",
+        )
+
+        with patch("docling_mcp.tools.converters.local.settings", service_settings):
+            converter = LocalDocumentConverter()
+            docling_converter = converter._get_converter()
+
+        pdf_option = docling_converter.format_to_options[InputFormat.PDF]
+        image_option = docling_converter.format_to_options[InputFormat.IMAGE]
+        assert isinstance(pdf_option, PdfFormatOption)
+        assert isinstance(image_option, ImageFormatOption)
+
+        for format_option in (pdf_option, image_option):
+            assert format_option.pipeline_cls is VlmPipeline
+            assert isinstance(format_option.pipeline_options, VlmPipelineOptions)
+            assert format_option.pipeline_options.enable_remote_services is True
+
+        assert pdf_option.pipeline_options == image_option.pipeline_options
+        pipeline_options = pdf_option.pipeline_options
+        assert isinstance(pipeline_options, VlmPipelineOptions)
+        vlm_options = pipeline_options.vlm_options
+        assert isinstance(vlm_options, VlmConvertOptions)
+        preset = VlmConvertOptions.get_preset("granite_docling")
+        assert vlm_options.model_spec == preset.model_spec
+        assert isinstance(vlm_options.engine_options, ApiVlmEngineOptions)
+        assert vlm_options.engine_options.engine_type is VlmEngineType.API_OLLAMA
+        assert vlm_options.engine_options.params == {}
+        assert (
+            str(vlm_options.engine_options.url)
+            == "http://localhost:11434/v1/chat/completions"
+        )
+
+    @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
+    def test_get_converter_normalizes_trailing_slash_in_vlm_host(self) -> None:
+        service_settings = ServiceClientSettings(
+            _env_file=None,
+            use_vlm=True,
+            vlm_host="http://ollama.test:8080/",
+        )
+
+        with patch("docling_mcp.tools.converters.local.settings", service_settings):
+            converter = LocalDocumentConverter()
+            docling_converter = converter._get_converter()
+
+        pipeline_options = docling_converter.format_to_options[
+            InputFormat.PDF
+        ].pipeline_options
+        assert isinstance(pipeline_options, VlmPipelineOptions)
+        assert isinstance(pipeline_options.vlm_options, VlmConvertOptions)
+        assert isinstance(
+            pipeline_options.vlm_options.engine_options, ApiVlmEngineOptions
+        )
+        assert (
+            str(pipeline_options.vlm_options.engine_options.url)
+            == "http://ollama.test:8080/v1/chat/completions"
+        )
 
     @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
     def test_is_available_when_installed(self) -> None:


### PR DESCRIPTION
## Summary

Add an opt-in local VLM conversion path for PDFs and images using Docling's `granite_docling` preset through Ollama. Local mode continues to use the standard pipeline unless `DOCLING_MCP_USE_VLM=true`.

## Changes

- add `use_vlm` and `vlm_host` service settings and expose them in the bundle manifest
- configure `ApiVlmEngineOptions` with `API_OLLAMA`, normalizing the host to `/v1/chat/completions`
- use separate PDF and image format options on the VLM path
- document setup and cover the default and VLM conversion paths

## Validation

- `pytest` (30 passed)
- Ruff, MyPy, lockfile validation, manifest validation, pre-commit hooks, and package build

Resolves #105
