### PR TITLE
feat(convert): expose pipeline overrides as per-call params

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,36 @@ In **[LM Studio](https://lmstudio.ai/)**, edit the `mcp.json` file with the appr
 
 Other integrations are described in the [integrations] page.
 
+## Pipeline overrides (per-call + env-var fallback)
+
+The convert tool exposes four optional pipeline overrides. When omitted, each
+falls back to its environment-variable default — but for one-off calls (born-
+digital PDF that needs no OCR, single document where you also want page
+images, switching between local and remote mid-session), passing them per-call
+avoids server-restart churn.
+
+```python
+docling-pr-95:convert_document_into_docling_document(
+    source="/path/to/born-digital.pdf",
+    do_ocr=False,              # skip OCR for clean PDFs (huge speed-up)
+    do_table_structure=False,  # skip table layout analysis
+    keep_images=True,          # enable page_thumbnail downstream
+    conversion_mode="local",   # use local converter even if env says remote
+)
+```
+
+| Param | Env-var default | Behavior |
+|---|---|---|
+| `do_ocr` | `DOCLING_MCP_DO_OCR` (default `true`) | Run OCR over every page. Disable for born-digital PDFs to skip a multi-minute step. |
+| `do_table_structure` | `DOCLING_MCP_DO_TABLE_STRUCTURE` (default `true`) | Detect table layout. Disable for plain-text PDFs. |
+| `keep_images` | `DOCLING_MCP_KEEP_IMAGES` (default `false`) | Generate per-page images at convert time. Required if you'll call `page_thumbnail` afterward — images are not retrievable after the fact. |
+| `conversion_mode` | `DOCLING_CONVERSION_MODE` (default `remote`) | `local` uses `DocumentConverter` from the `[local]` extra. `remote` requires `DOCLING_SERVICE_URL` to be set. |
+
+Per-call overrides take precedence; env vars are the fallback default for
+calls that omit them. The `LocalDocumentConverter` caches one underlying
+`DocumentConverter` instance per unique override tuple, so repeated calls
+with the same options don't pay the model-load cost twice.
+
 ## Examples
 
 ### Converting documents

--- a/docling_mcp/tools/conversion.py
+++ b/docling_mcp/tools/conversion.py
@@ -64,6 +64,53 @@ def convert_document_into_docling_document(
         str,
         Field(description="The URL or local file path to the document."),
     ],
+    do_ocr: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description=(
+                "Override OCR for this call. None = use DOCLING_MCP_DO_OCR env "
+                "default (True). Set False on born-digital PDFs to skip the OCR "
+                "step entirely — typically the difference between a multi-minute "
+                "conversion and a sub-second one."
+            ),
+        ),
+    ] = None,
+    do_table_structure: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description=(
+                "Override table-structure detection for this call. None = use "
+                "DOCLING_MCP_DO_TABLE_STRUCTURE env default (True). Set False "
+                "for plain-text PDFs to skip table layout analysis."
+            ),
+        ),
+    ] = None,
+    keep_images: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description=(
+                "Override per-page image generation for this call. None = use "
+                "DOCLING_MCP_KEEP_IMAGES env default (False). Set True when the "
+                "caller plans to use the page_thumbnail tool afterward; images "
+                "are generated at convert time, not retrievable after the fact."
+            ),
+        ),
+    ] = None,
+    conversion_mode: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Override converter selection for this call. One of 'local' or "
+                "'remote'. None = use DOCLING_CONVERSION_MODE env default "
+                "(remote). Use 'local' when DOCLING_SERVICE_URL is not "
+                "configured to avoid the remote-mode bootstrap error."
+            ),
+        ),
+    ] = None,
 ) -> ConversionOutput:
     """Convert a document of any type from a URL or local path and store in local cache.
 
@@ -73,10 +120,21 @@ def convert_document_into_docling_document(
     set to False along with the document's unique cache key. If the document
     was already in the local cache, the conversion is skipped and the output
     boolean is set to True.
+
+    All four pipeline overrides (do_ocr, do_table_structure, keep_images,
+    conversion_mode) are optional. When None, the server falls back to the
+    corresponding env-var default. Set them per-call when you know something
+    about the document the env-var defaults can't (e.g., this PDF is born-
+    digital, skip OCR).
     """
     try:
-        converter = get_converter()
-        result = converter.convert_document(source)
+        converter = get_converter(conversion_mode=conversion_mode)
+        result = converter.convert_document(
+            source,
+            do_ocr=do_ocr,
+            do_table_structure=do_table_structure,
+            keep_images=keep_images,
+        )
 
         # Clean up memory after conversion
         cleanup_memory()

--- a/docling_mcp/tools/converters/base.py
+++ b/docling_mcp/tools/converters/base.py
@@ -15,8 +15,19 @@ class ConversionOutput:
 class DocumentConverterProtocol(Protocol):
     """Protocol for document converters."""
 
-    def convert_document(self, source: str) -> ConversionOutput:
-        """Convert a single document."""
+    def convert_document(
+        self,
+        source: str,
+        do_ocr: bool | None = None,
+        do_table_structure: bool | None = None,
+        keep_images: bool | None = None,
+    ) -> ConversionOutput:
+        """Convert a single document.
+
+        All pipeline-option overrides are optional; when None, the converter
+        falls back to its environment-variable defaults (DOCLING_MCP_DO_OCR,
+        DOCLING_MCP_DO_TABLE_STRUCTURE, DOCLING_MCP_KEEP_IMAGES).
+        """
         ...
 
     def convert_directory(self, source: str) -> list[ConversionOutput]:

--- a/docling_mcp/tools/converters/factory.py
+++ b/docling_mcp/tools/converters/factory.py
@@ -12,14 +12,27 @@ if TYPE_CHECKING:
 logger = setup_logger()
 
 
-def get_converter() -> Union["RemoteDocumentConverter", "LocalDocumentConverter"]:
-    """Get the appropriate converter based on settings."""
+def get_converter(
+    conversion_mode: ConversionMode | str | None = None,
+) -> Union["RemoteDocumentConverter", "LocalDocumentConverter"]:
+    """Get the appropriate converter based on settings.
+
+    Args:
+        conversion_mode: Optional per-call override for the conversion mode.
+            When None, falls back to the DOCLING_CONVERSION_MODE environment
+            variable (default: REMOTE).
+    """
     # Import converters lazily to avoid importing DocumentConverter when not needed
     from .remote import RemoteDocumentConverter
 
-    logger.info(f"Selecting converter for mode: {settings.conversion_mode}")
+    effective_mode = (
+        ConversionMode(conversion_mode)
+        if conversion_mode is not None
+        else settings.conversion_mode
+    )
+    logger.info(f"Selecting converter for mode: {effective_mode}")
 
-    if settings.conversion_mode == ConversionMode.REMOTE:
+    if effective_mode == ConversionMode.REMOTE:
         try:
             converter = RemoteDocumentConverter()
             if converter.is_available():
@@ -59,7 +72,7 @@ def get_converter() -> Union["RemoteDocumentConverter", "LocalDocumentConverter"
         # No fallback, return the unavailable converter
         return converter
 
-    elif settings.conversion_mode == ConversionMode.LOCAL:
+    elif effective_mode == ConversionMode.LOCAL:
         # Import local converter only when needed
         from .local import LOCAL_CONVERSION_AVAILABLE, LocalDocumentConverter
 
@@ -71,4 +84,4 @@ def get_converter() -> Union["RemoteDocumentConverter", "LocalDocumentConverter"
         logger.info("Using local converter")
         return LocalDocumentConverter()
 
-    raise ValueError(f"Unknown conversion mode: {settings.conversion_mode}")
+    raise ValueError(f"Unknown conversion mode: {effective_mode}")

--- a/docling_mcp/tools/converters/local.py
+++ b/docling_mcp/tools/converters/local.py
@@ -39,31 +39,67 @@ class LocalDocumentConverter:
                 "Local conversion requires docling-mcp[local] extra. "
                 "Install with: pip install docling-mcp[local]"
             )
-        self._converter: DocumentConverter | None = None
+        # Cache one DocumentConverter per unique pipeline-option tuple so that
+        # repeated calls with the same overrides don't re-instantiate the
+        # underlying models.
+        self._converter_cache: dict[tuple[bool, bool, bool], DocumentConverter] = {}
         logger.info("Initialized local document converter")
 
-    def _get_converter(self) -> "DocumentConverter":
-        """Get or create DocumentConverter instance."""
-        if self._converter is not None:
-            return self._converter
+    def _get_converter(
+        self,
+        do_ocr: bool | None = None,
+        do_table_structure: bool | None = None,
+        keep_images: bool | None = None,
+    ) -> "DocumentConverter":
+        """Get or create DocumentConverter instance for the given pipeline options.
+
+        When an override is None, the corresponding env-var setting is used.
+        Returns a cached converter when the same tuple of options has been
+        requested before, so per-call overrides don't pay the model-load cost
+        on every invocation.
+        """
+        effective_do_ocr = do_ocr if do_ocr is not None else settings.do_ocr
+        effective_do_table = (
+            do_table_structure
+            if do_table_structure is not None
+            else settings.do_table_structure
+        )
+        effective_keep_images = (
+            keep_images if keep_images is not None else settings.keep_images
+        )
+
+        key = (effective_do_ocr, effective_do_table, effective_keep_images)
+        if key in self._converter_cache:
+            return self._converter_cache[key]
 
         pipeline_options = PdfPipelineOptions()
-        pipeline_options.generate_page_images = settings.keep_images
+        pipeline_options.generate_page_images = effective_keep_images
         pipeline_options.images_scale = settings.images_scale
-        pipeline_options.do_ocr = settings.do_ocr
-        pipeline_options.do_table_structure = settings.do_table_structure
+        pipeline_options.do_ocr = effective_do_ocr
+        pipeline_options.do_table_structure = effective_do_table
 
         format_options: dict[InputFormat, FormatOption] = {
             InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
             InputFormat.IMAGE: PdfFormatOption(pipeline_options=pipeline_options),
         }
 
-        logger.info(f"Creating DocumentConverter with options: {format_options}")
-        self._converter = DocumentConverter(format_options=format_options)
-        return self._converter
+        logger.info(
+            f"Creating DocumentConverter with do_ocr={effective_do_ocr}, "
+            f"do_table_structure={effective_do_table}, "
+            f"keep_images={effective_keep_images}"
+        )
+        converter = DocumentConverter(format_options=format_options)
+        self._converter_cache[key] = converter
+        return converter
 
-    def convert_document(self, source: str) -> ConversionOutput:
-        """Convert document using local converter."""
+    def convert_document(
+        self,
+        source: str,
+        do_ocr: bool | None = None,
+        do_table_structure: bool | None = None,
+        keep_images: bool | None = None,
+    ) -> ConversionOutput:
+        """Convert document using local converter, optionally overriding pipeline opts."""
         source = source.strip("\"'")
         logger.info(f"Converting document locally: {source}")
 
@@ -73,8 +109,12 @@ class LocalDocumentConverter:
             logger.info(f"Document found in cache: {cache_key}")
             return ConversionOutput(True, cache_key)
 
-        # Get converter and convert
-        converter = self._get_converter()
+        # Get converter for the requested pipeline options (None = env default)
+        converter = self._get_converter(
+            do_ocr=do_ocr,
+            do_table_structure=do_table_structure,
+            keep_images=keep_images,
+        )
         result = converter.convert(source)
 
         # Check for errors

--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -40,8 +40,14 @@ class RemoteDocumentConverter:
         )
         logger.info(f"Initialized remote converter with URL: {settings.service_url}")
 
-    def convert_document(self, source: str) -> ConversionOutput:
-        """Convert document using remote API."""
+    def convert_document(
+        self,
+        source: str,
+        do_ocr: bool | None = None,
+        do_table_structure: bool | None = None,
+        keep_images: bool | None = None,
+    ) -> ConversionOutput:
+        """Convert document using remote API, optionally overriding pipeline opts."""
         source = source.strip("\"'")
         logger.info(f"Converting document via remote API: {source}")
 
@@ -51,11 +57,25 @@ class RemoteDocumentConverter:
             logger.info(f"Document found in cache: {cache_key}")
             return ConversionOutput(True, cache_key)
 
+        # Resolve per-call overrides; fall back to ServiceClientSettings env
+        # defaults (the settings class this remote path actually reads from
+        # as of #116 — do not fall back to ConversionSettings here, that's
+        # the local-converter-only settings object).
+        effective_do_ocr = do_ocr if do_ocr is not None else settings.do_ocr
+        effective_do_table = (
+            do_table_structure
+            if do_table_structure is not None
+            else settings.do_table_structure
+        )
+        effective_keep_images = (
+            keep_images if keep_images is not None else settings.keep_images
+        )
+
         # Configure conversion options
         options = ConvertDocumentsOptions(
-            do_ocr=settings.do_ocr,
-            do_table_structure=settings.do_table_structure,
-            include_images=settings.keep_images,
+            do_ocr=effective_do_ocr,
+            do_table_structure=effective_do_table,
+            include_images=effective_keep_images,
             images_scale=settings.images_scale,
             to_formats=[OutputFormat.JSON],
             abort_on_error=False,

--- a/tests/test_pipeline_overrides.py
+++ b/tests/test_pipeline_overrides.py
@@ -1,0 +1,148 @@
+"""Tests for per-call pipeline-option overrides on convert_document.
+
+The MCP `convert_document_into_docling_document` tool exposes optional
+per-call overrides for `do_ocr`, `do_table_structure`, `keep_images`, and
+`conversion_mode`. These tests verify the override plumbing without
+spinning up a real DocumentConverter.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Factory: conversion_mode override
+# ---------------------------------------------------------------------------
+
+
+def test_get_converter_accepts_mode_override() -> None:
+    """get_converter accepts a conversion_mode argument."""
+    from docling_mcp.tools.converters.factory import get_converter
+
+    sig = inspect.signature(get_converter)
+    assert "conversion_mode" in sig.parameters
+    assert sig.parameters["conversion_mode"].default is None
+
+
+def test_get_converter_override_routes_to_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing conversion_mode='local' routes to LocalDocumentConverter regardless of env.
+
+    Note: factory uses lazy imports inside get_converter(), so we patch the
+    symbols at their source modules rather than on the factory module. That
+    means this test requires the [local] extra (docling) to be importable.
+    """
+    pytest.importorskip("docling")
+    from docling_mcp.settings.service_client import ConversionMode, settings
+    from docling_mcp.tools.converters import factory
+
+    # Pretend env said REMOTE so the override is what changes routing
+    monkeypatch.setattr(settings, "conversion_mode", ConversionMode.REMOTE)
+
+    # Patch the source symbols (factory imports them inside the function)
+    with patch(
+        "docling_mcp.tools.converters.remote.RemoteDocumentConverter"
+    ) as remote_cls:
+        with patch(
+            "docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True
+        ):
+            with patch(
+                "docling_mcp.tools.converters.local.LocalDocumentConverter"
+            ) as local_cls:
+                factory.get_converter(conversion_mode="local")
+                local_cls.assert_called_once()
+                remote_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# LocalDocumentConverter: per-call pipeline overrides
+# ---------------------------------------------------------------------------
+
+
+def test_local_get_converter_accepts_overrides() -> None:
+    """LocalDocumentConverter._get_converter exposes the three pipeline overrides."""
+    pytest.importorskip("docling")  # only runs when [local] extra is installed
+    from docling_mcp.tools.converters.local import LocalDocumentConverter
+
+    sig = inspect.signature(LocalDocumentConverter._get_converter)
+    for name in ("do_ocr", "do_table_structure", "keep_images"):
+        assert name in sig.parameters, f"missing param: {name}"
+        assert sig.parameters[name].default is None
+
+
+def test_local_convert_document_accepts_overrides() -> None:
+    """LocalDocumentConverter.convert_document forwards overrides to _get_converter."""
+    pytest.importorskip("docling")
+    from docling_mcp.tools.converters.local import LocalDocumentConverter
+
+    sig = inspect.signature(LocalDocumentConverter.convert_document)
+    for name in ("do_ocr", "do_table_structure", "keep_images"):
+        assert name in sig.parameters, f"missing param: {name}"
+        assert sig.parameters[name].default is None
+
+
+def test_local_converter_cache_keyed_by_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Different option tuples yield different cached DocumentConverter instances."""
+    pytest.importorskip("docling")
+    from docling_mcp.tools.converters import local as local_module
+    from docling_mcp.tools.converters.local import LocalDocumentConverter
+
+    # Replace the underlying DocumentConverter with a counter mock
+    construct_calls: list[dict[str, object]] = []
+
+    def fake_dc(format_options: object = None, **kw: object) -> MagicMock:
+        construct_calls.append({"format_options": format_options})
+        return MagicMock(name="FakeDocumentConverter")
+
+    monkeypatch.setattr(local_module, "DocumentConverter", fake_dc)
+
+    conv = LocalDocumentConverter()
+
+    # Two calls with same options → one underlying instance
+    a1 = conv._get_converter(do_ocr=False, do_table_structure=False, keep_images=False)
+    a2 = conv._get_converter(do_ocr=False, do_table_structure=False, keep_images=False)
+    assert a1 is a2
+
+    # Different option tuple → new instance
+    b = conv._get_converter(do_ocr=True, do_table_structure=False, keep_images=False)
+    assert b is not a1
+
+    assert len(construct_calls) == 2  # one per unique tuple
+
+
+# ---------------------------------------------------------------------------
+# Remote converter: override plumbing (signature only — no live API)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_convert_document_accepts_overrides() -> None:
+    """RemoteDocumentConverter.convert_document accepts the three pipeline overrides."""
+    pytest.importorskip("docling")
+    from docling_mcp.tools.converters.remote import RemoteDocumentConverter
+
+    sig = inspect.signature(RemoteDocumentConverter.convert_document)
+    for name in ("do_ocr", "do_table_structure", "keep_images"):
+        assert name in sig.parameters, f"missing param: {name}"
+        assert sig.parameters[name].default is None
+
+
+# ---------------------------------------------------------------------------
+# MCP tool surface
+# ---------------------------------------------------------------------------
+
+
+def test_convert_tool_exposes_all_four_overrides() -> None:
+    """The convert_document_into_docling_document MCP tool surface includes the overrides."""
+    pytest.importorskip("docling")
+    from docling_mcp.tools.conversion import convert_document_into_docling_document
+
+    sig = inspect.signature(convert_document_into_docling_document)
+    for name in ("do_ocr", "do_table_structure", "keep_images", "conversion_mode"):
+        assert name in sig.parameters, f"missing tool param: {name}"
+        assert sig.parameters[name].default is None


### PR DESCRIPTION
Closes #109.

Implementation of the proposed fix in #109. One commit, 7 files, additive at the tool surface — existing callers see no behavior change because all four new params default to None (= use env-var fallback).

See the issue body for full motivation. See the commit message for the file-by-file change rationale.

Tests: 7 new cases in tests/test_pipeline_overrides.py covering signature surface, factory routing, local converter per-tuple caching, and remote converter override plumbing.

Local verification: pre-commit run --all-files green (mypy clean on all patch-touched files — 2 pre-existing, unrelated llama_index import errors remain on files this PR doesn't touch, due to that optional extra not being installed locally), pytest green (7/7).