### PR TITLE
docs: fix broken link to non-existent docs/development.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Depending on the transfer protocol required, specify the argument `--transport`,
 
 More options are available, e.g. the selection of which toolgroup to launch. Use the `--help` argument to inspect all the CLI options.
 
-For developing the MCP tools further, please refer to the [docs/development.md](docs/development.md) page for instructions.
+For developing the MCP tools further, please refer to the [Developing](CONTRIBUTING.md#developing) section of CONTRIBUTING.md for instructions.
 
 ## Integration with MCP clients
 


### PR DESCRIPTION
## Summary
- The README linked to `docs/development.md`, which doesn't exist in the repo.
- `CONTRIBUTING.md` already has a `## Developing` section covering cloning, `uv` setup, dev-mode usage, and code style — so this points the link there instead of creating a duplicate file.

## Test plan
- [x] Confirmed `docs/development.md` doesn't exist anywhere in the repo.
- [x] Confirmed `CONTRIBUTING.md#developing` renders and anchors correctly on GitHub.