### PR TITLE
feat: add persistent document store, corpus search, and object-storage sources

### DIFF
--- a/docling_mcp/docling_cache.py
+++ b/docling_mcp/docling_cache.py
@@ -1,6 +1,7 @@
 """This module manages the cache directory to run Docling MCP tools."""
 
 import hashlib
+import importlib.metadata
 import json
 import os
 import sys
@@ -67,15 +68,109 @@ def get_cache_dir() -> Path:
     return cache_path
 
 
+def _file_content_digest(path: Path) -> str:
+    """Return the SHA-256 digest of a file's content.
+
+    The content is hashed on every call: the cost is negligible next to a
+    conversion, and stat-based caching cannot reliably detect same-size
+    rewrites with preserved timestamps.
+    """
+    hasher = hashlib.sha256(usedforsecurity=False)
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+# Version stamps invalidate persisted results when the packages that produce
+# them change behavior.
+_VERSION_STAMP = {
+    "docling_mcp": _package_version("docling-mcp"),
+    "docling": _package_version("docling-slim") or _package_version("docling"),
+}
+
+
+def local_conversion_context() -> dict[str, object]:
+    """Return the cache-key context for conversions executed locally."""
+    from docling_mcp.settings.conversion import settings as conversion_settings
+
+    return {
+        "mode": "local",
+        "do_ocr": conversion_settings.do_ocr,
+        "do_table_structure": conversion_settings.do_table_structure,
+        "keep_images": conversion_settings.keep_images,
+        "versions": _VERSION_STAMP,
+    }
+
+
+def remote_conversion_context() -> dict[str, object]:
+    """Return the cache-key context for conversions delegated to docling-serve."""
+    from docling_mcp.settings.service_client import settings as service_settings
+
+    return {
+        "mode": "remote",
+        "service_url": service_settings.service_url,
+        "versions": _VERSION_STAMP,
+    }
+
+
+def _default_conversion_context() -> dict[str, object]:
+    from docling_mcp.settings.service_client import (
+        ConversionMode,
+        settings as service_settings,
+    )
+
+    if service_settings.conversion_mode == ConversionMode.REMOTE:
+        return remote_conversion_context()
+    return local_conversion_context()
+
+
 def get_cache_key(
-    source: str, enable_ocr: bool = False, ocr_language: list[str] | None = None
+    source: str,
+    enable_ocr: bool = False,
+    ocr_language: list[str] | None = None,
+    conversion: dict[str, object] | None = None,
 ) -> str:
-    """Generate a cache key for the document conversion."""
-    key_data = {
-        "source": source,
+    """Generate a cache key for the document conversion.
+
+    Local files are keyed by their content digest, so identical files reached
+    through different paths share one conversion and edited files trigger a
+    new one. Other sources (URLs) are keyed by the source string. The key also
+    covers the conversion configuration, so results persisted under a
+    different mode or pipeline setup are not reused. Converters should pass
+    their own `conversion` context so fallback conversions are keyed by the
+    converter that actually ran, not by the configured mode.
+    """
+    key_data: dict[str, object] = {
         "enable_ocr": enable_ocr,
         "ocr_language": ocr_language or [],
+        "conversion": conversion
+        if conversion is not None
+        else _default_conversion_context(),
     }
+
+    is_file = False
+    try:
+        path = Path(source)
+        is_file = path.is_file()
+    except OSError:
+        is_file = False
+
+    if is_file:
+        key_data["content"] = _file_content_digest(path)
+        # The suffix selects the input format, so identical bytes under
+        # different extensions must not share a conversion.
+        key_data["format"] = path.suffix.lower()
+    else:
+        key_data["source"] = source
+
     key_str = json.dumps(key_data, sort_keys=True)
     hash = hash_string(key_str)
     return hash[:32]

--- a/docling_mcp/logger.py
+++ b/docling_mcp/logger.py
@@ -9,8 +9,15 @@ def setup_logger() -> logging.Logger:
     logger = logging.getLogger("docling_mcp")
     logger.setLevel(logging.INFO)
 
+    # Repeated calls must not stack handlers, or every record is emitted
+    # once per module that called setup_logger(). Only this module's own
+    # handler counts; host-installed handlers do not suppress setup.
+    if any(h.name == "docling_mcp" for h in logger.handlers):
+        return logger
+
     # Create a handler and set its level to INFO
     handler = logging.StreamHandler()
+    handler.name = "docling_mcp"
     handler.setLevel(logging.INFO)
 
     # Create a formatter and add it to the handler
@@ -19,7 +26,9 @@ def setup_logger() -> logging.Logger:
     )
     handler.setFormatter(formatter)
 
-    # Add the handler to the logger
+    # Add the handler to the logger; records are fully handled here, so do
+    # not also propagate them to the root logger's handlers
     logger.addHandler(handler)
+    logger.propagate = False
 
     return logger

--- a/docling_mcp/servers/mcp_server.py
+++ b/docling_mcp/servers/mcp_server.py
@@ -17,6 +17,7 @@ class ToolGroups(str, enum.Enum):
     CONVERSION = "conversion"
     GENERATION = "generation"
     MANIPULATION = "manipulation"
+    CORPUS = "corpus"
     LLAMA_INDEX_RAG = "llama-index-rag"
     LLAMA_STACK_RAG = "llama-stack-rag"
     LLAMA_STACK_IE = "llama-stack-ie"
@@ -30,7 +31,12 @@ class TransportType(str, enum.Enum):
     STREAMABLE_HTTP = "streamable-http"
 
 
-_DEFAULT_TOOLS = [ToolGroups.CONVERSION, ToolGroups.GENERATION, ToolGroups.MANIPULATION]
+_DEFAULT_TOOLS = [
+    ToolGroups.CONVERSION,
+    ToolGroups.GENERATION,
+    ToolGroups.MANIPULATION,
+    ToolGroups.CORPUS,
+]
 
 
 @app.command()
@@ -63,6 +69,10 @@ def main(
     if ToolGroups.MANIPULATION in tools:
         logger.info("loading manipulation tools...")
         import docling_mcp.tools.manipulation
+
+    if ToolGroups.CORPUS in tools:
+        logger.info("loading corpus tools...")
+        import docling_mcp.tools.corpus
 
     if ToolGroups.LLAMA_INDEX_RAG in tools:
         logger.info("loading Llama Index RAG tools...")

--- a/docling_mcp/settings/store.py
+++ b/docling_mcp/settings/store.py
@@ -1,0 +1,25 @@
+"""Settings for the document store."""
+
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class StoreSettings(BaseSettings):
+    """Settings for the document store."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="DOCLING_MCP_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    # Base cache directory; persisted documents live in a "documents"
+    # subdirectory beneath it. Defaults to the application cache dir.
+    cache_dir: Path | None = None
+
+    # Persist converted documents to disk so they survive server restarts
+    cache_persist: bool = True
+
+
+settings = StoreSettings()

--- a/docling_mcp/shared.py
+++ b/docling_mcp/shared.py
@@ -1,13 +1,22 @@
 """This module defines shared resources."""
 
+from collections import defaultdict
+
 from mcp.server.fastmcp import FastMCP
 
-from docling_core.types.doc.document import DoclingDocument
 from docling_core.types.doc.items.node import NodeItem
+
+from docling_mcp.store.base import DocumentStoreProtocol
+from docling_mcp.store.factory import create_document_store
 
 # Create a single shared FastMCP instance
 mcp = FastMCP("docling")
 
-# Define your shared cache here if it's used by multiple tools
-local_document_cache: dict[str, DoclingDocument] = {}
-local_stack_cache: dict[str, list[NodeItem]] = {}
+# Shared document cache used by multiple tools. Converted documents are
+# persisted across server restarts unless persistence is disabled.
+local_document_cache: DocumentStoreProtocol = create_document_store()
+
+# In-progress authoring state; memory-only by design. A defaultdict so that
+# documents recovered from the persistent store (whose stack did not survive
+# the restart) fail with a clear empty-stack error instead of a KeyError.
+local_stack_cache: dict[str, list[NodeItem]] = defaultdict(list)

--- a/docling_mcp/store/__init__.py
+++ b/docling_mcp/store/__init__.py
@@ -1,0 +1,5 @@
+"""Document store package providing persistent caching of Docling documents."""
+
+from docling_mcp.store.base import DocumentMetadata, DocumentStoreProtocol
+from docling_mcp.store.factory import create_document_store
+from docling_mcp.store.local import InMemoryDocumentStore, LocalDocumentStore

--- a/docling_mcp/store/__init__.py
+++ b/docling_mcp/store/__init__.py
@@ -1,5 +1,9 @@
 """Document store package providing persistent caching of Docling documents."""
 
-from docling_mcp.store.base import DocumentMetadata, DocumentStoreProtocol
+from docling_mcp.store.base import (
+    CorpusSearchHit,
+    DocumentMetadata,
+    DocumentStoreProtocol,
+)
 from docling_mcp.store.factory import create_document_store
 from docling_mcp.store.local import InMemoryDocumentStore, LocalDocumentStore

--- a/docling_mcp/store/base.py
+++ b/docling_mcp/store/base.py
@@ -1,0 +1,76 @@
+"""Base types and protocols for document stores."""
+
+from collections.abc import Iterator, KeysView
+from typing import Protocol
+
+from pydantic import BaseModel
+
+from docling_core.types.doc.document import DoclingDocument
+
+
+class DocumentMetadata(BaseModel):
+    """Metadata record describing a stored document."""
+
+    document_key: str
+    name: str | None = None
+    source_filename: str | None = None
+    mimetype: str | None = None
+    binary_hash: int | None = None
+    num_pages: int = 0
+    stored_at: str | None = None
+
+    @classmethod
+    def from_document(
+        cls, document_key: str, document: DoclingDocument, stored_at: str | None
+    ) -> "DocumentMetadata":
+        """Build a metadata record from a document instance."""
+        origin = document.origin
+        return cls(
+            document_key=document_key,
+            name=document.name,
+            source_filename=origin.filename if origin is not None else None,
+            mimetype=origin.mimetype if origin is not None else None,
+            binary_hash=origin.binary_hash if origin is not None else None,
+            num_pages=len(document.pages),
+            stored_at=stored_at,
+        )
+
+
+class DocumentStoreProtocol(Protocol):
+    """Protocol for document stores.
+
+    Stores behave as mutable mappings from document key to DoclingDocument and
+    additionally expose metadata listing for corpus-level tools.
+    """
+
+    def __getitem__(self, document_key: str) -> DoclingDocument:
+        """Return the document stored under a key."""
+        ...
+
+    def __setitem__(self, document_key: str, document: DoclingDocument) -> None:
+        """Store a document under a key."""
+        ...
+
+    def __delitem__(self, document_key: str) -> None:
+        """Remove a document and its metadata."""
+        ...
+
+    def __contains__(self, document_key: object) -> bool:
+        """Return whether a document exists for the key."""
+        ...
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the stored document keys."""
+        ...
+
+    def __len__(self) -> int:
+        """Return the number of stored documents."""
+        ...
+
+    def keys(self) -> KeysView[str]:
+        """Return a view of the stored document keys."""
+        ...
+
+    def list_metadata(self) -> list[DocumentMetadata]:
+        """Return metadata records for all stored documents."""
+        ...

--- a/docling_mcp/store/base.py
+++ b/docling_mcp/store/base.py
@@ -36,11 +36,21 @@ class DocumentMetadata(BaseModel):
         )
 
 
+class CorpusSearchHit(BaseModel):
+    """One ranked match from a search across the stored documents."""
+
+    document_key: str
+    anchor: str
+    snippet: str
+    page: int | None = None
+
+
 class DocumentStoreProtocol(Protocol):
     """Protocol for document stores.
 
     Stores behave as mutable mappings from document key to DoclingDocument and
-    additionally expose metadata listing for corpus-level tools.
+    additionally expose metadata listing and lexical search for corpus-level
+    tools.
     """
 
     def __getitem__(self, document_key: str) -> DoclingDocument:
@@ -73,4 +83,13 @@ class DocumentStoreProtocol(Protocol):
 
     def list_metadata(self) -> list[DocumentMetadata]:
         """Return metadata records for all stored documents."""
+        ...
+
+    def search_corpus(
+        self,
+        query: str,
+        max_results: int,
+        document_keys: list[str] | None = None,
+    ) -> list[CorpusSearchHit]:
+        """Return ranked lexical matches across the stored documents."""
         ...

--- a/docling_mcp/store/factory.py
+++ b/docling_mcp/store/factory.py
@@ -1,0 +1,50 @@
+"""Factory for creating the document store based on configuration."""
+
+from pathlib import Path
+
+from docling_mcp.docling_cache import get_cache_dir
+from docling_mcp.logger import setup_logger
+from docling_mcp.settings.store import settings
+from docling_mcp.store.base import DocumentStoreProtocol
+from docling_mcp.store.local import InMemoryDocumentStore, LocalDocumentStore
+
+logger = setup_logger()
+
+
+def _fallback_cache_dir() -> Path:
+    return Path.home() / ".cache" / "docling-mcp"
+
+
+def create_document_store() -> DocumentStoreProtocol:
+    """Create the document store selected by the store settings.
+
+    Falls back to a per-user cache directory when the default location is not
+    writable (for example a read-only site-packages install), and to the
+    in-memory store when no writable location exists at all.
+    """
+    if not settings.cache_persist:
+        logger.info("Document persistence disabled; using in-memory store")
+        return InMemoryDocumentStore()
+
+    if settings.cache_dir is not None:
+        candidates = [settings.cache_dir]
+    else:
+        candidates = []
+        try:
+            candidates.append(get_cache_dir())
+        except OSError:
+            logger.warning("Default cache directory is not available")
+        candidates.append(_fallback_cache_dir())
+
+    for base_dir in candidates:
+        cache_dir = base_dir / "documents"
+        try:
+            store = LocalDocumentStore(cache_dir=cache_dir)
+        except OSError:
+            logger.warning(f"Document store location not writable: {cache_dir}")
+            continue
+        logger.info(f"Using local document store at: {cache_dir}")
+        return store
+
+    logger.error("No writable document store location; falling back to in-memory store")
+    return InMemoryDocumentStore()

--- a/docling_mcp/store/index.py
+++ b/docling_mcp/store/index.py
@@ -1,0 +1,288 @@
+"""SQLite FTS5 search index over the items of stored documents."""
+
+import os
+import re
+import sqlite3
+import threading
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+from docling_core.types.doc.document import DoclingDocument
+from docling_core.types.doc.items.node import DocItem
+from docling_core.types.doc.items.table.table import TableItem
+
+from docling_mcp.logger import setup_logger
+from docling_mcp.store.base import CorpusSearchHit
+
+logger = setup_logger()
+
+_SCHEMA_VERSION = 1
+
+# Column order of the corpus table; snippet() addresses text by position.
+_TEXT_COLUMN = 4
+
+_TOKEN_PATTERN = re.compile(r"\w+", re.UNICODE)
+
+
+def _iter_index_rows(
+    document_key: str, document: DoclingDocument
+) -> Iterator[tuple[str, str, str, int | None, str]]:
+    """Yield one (key, anchor, label, page, text) row per searchable item.
+
+    Rows come from the document body via iterate_items(), so furniture such
+    as the converter-added source line is not indexed. Tables contribute the
+    concatenated text of their cells.
+    """
+    for item, _level in document.iterate_items():
+        if not isinstance(item, DocItem):
+            continue
+        if isinstance(item, TableItem):
+            text = " ".join(cell.text for cell in item.data.table_cells if cell.text)
+        else:
+            text = getattr(item, "text", "") or ""
+        text = text.strip()
+        if not text:
+            continue
+        page = item.prov[0].page_no if item.prov else None
+        yield (document_key, item.get_ref().cref, item.label.value, page, text)
+
+
+def _fts_match_expression(query: str) -> str:
+    """Build a safe FTS5 MATCH expression from a free-text query.
+
+    Each word is quoted so FTS5 query syntax in the input (operators,
+    parentheses, dangling quotes) cannot raise a parse error; the quoted
+    words combine with FTS5's implicit AND.
+    """
+    tokens = _TOKEN_PATTERN.findall(query)
+    return " ".join(f'"{token}"' for token in tokens)
+
+
+class CorpusIndex:
+    """Lexical search index stored beside the persisted documents.
+
+    The index is derived data with the same trust model as the metadata
+    sidecars: it can always be rebuilt from the stored documents, so index
+    writes never fail document storage. A corrupt database file is
+    quarantined and replaced with an empty index, which the owning store
+    repopulates during its sync-on-search pass. When SQLite lacks the FTS5
+    extension, indexing degrades to a no-op and searches raise a clear
+    error; see the fallback open question in the design notes.
+
+    Access is serialized by an internal lock because MCP tool calls can run
+    on different threads while SQLite connections default to single-thread
+    affinity.
+    """
+
+    def __init__(self, db_path: Path | None) -> None:
+        self._path = db_path
+        self._lock = threading.RLock()
+        self._conn: sqlite3.Connection | None = None
+        self._fts5_available = True
+        self._connect()
+
+    def _connect(self) -> None:
+        target = str(self._path) if self._path is not None else ":memory:"
+        try:
+            conn = sqlite3.connect(target, check_same_thread=False)
+        except sqlite3.Error:
+            logger.exception(f"Could not open corpus index: {target}")
+            self._conn = None
+            return
+        try:
+            self._init_schema(conn)
+        except sqlite3.DatabaseError:
+            conn.close()
+            if self._quarantine():
+                try:
+                    conn = sqlite3.connect(target, check_same_thread=False)
+                    self._init_schema(conn)
+                except sqlite3.Error:
+                    logger.exception(f"Could not recreate corpus index: {target}")
+                    self._conn = None
+                    return
+            else:
+                self._conn = None
+                return
+        self._conn = conn
+        if self._path is not None:
+            try:
+                os.chmod(self._path, 0o600)
+            except OSError:
+                logger.warning(f"Could not restrict corpus index mode: {self._path}")
+
+    def _init_schema(self, conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA busy_timeout = 5000")
+        try:
+            conn.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS corpus USING fts5("
+                "document_key UNINDEXED, anchor UNINDEXED, label UNINDEXED, "
+                "page UNINDEXED, text)"
+            )
+        except sqlite3.OperationalError as exc:
+            if "fts5" in str(exc).lower():
+                logger.warning(
+                    f"SQLite FTS5 unavailable; corpus search disabled: {exc}"
+                )
+                self._fts5_available = False
+                return
+            raise
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS indexed_documents("
+            "document_key TEXT PRIMARY KEY)"
+        )
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        if version != _SCHEMA_VERSION:
+            with conn:
+                conn.execute("DELETE FROM corpus")
+                conn.execute("DELETE FROM indexed_documents")
+                conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+
+    def _quarantine(self) -> bool:
+        """Move a corrupt database file aside; return whether a retry makes sense."""
+        if self._path is None:
+            return False
+        quarantine = self._path.with_name(
+            f"{self._path.name}.corrupt-{os.getpid()}-{uuid.uuid4().hex}"
+        )
+        try:
+            os.replace(self._path, quarantine)
+        except OSError:
+            logger.warning(f"Could not quarantine corpus index: {self._path}")
+            return False
+        logger.warning(f"Quarantined corrupt corpus index to: {quarantine}")
+        return True
+
+    def _recover(self) -> None:
+        """Drop the broken connection, quarantine the file, and reconnect."""
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except sqlite3.Error:
+                logger.warning("Could not close broken corpus index connection")
+            self._conn = None
+        self._quarantine()
+        self._connect()
+
+    @property
+    def available(self) -> bool:
+        """Return whether the index can serve searches."""
+        return self._conn is not None and self._fts5_available
+
+    def index_document(self, document_key: str, document: DoclingDocument) -> None:
+        """Replace the indexed rows for a document; never raises."""
+        rows = list(_iter_index_rows(document_key, document))
+        with self._lock:
+            if not self.available:
+                return
+            assert self._conn is not None
+            try:
+                with self._conn:
+                    self._conn.execute(
+                        "DELETE FROM corpus WHERE document_key = ?", (document_key,)
+                    )
+                    self._conn.executemany(
+                        "INSERT INTO corpus(document_key, anchor, label, page, text) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        rows,
+                    )
+                    self._conn.execute(
+                        "INSERT OR REPLACE INTO indexed_documents(document_key) "
+                        "VALUES (?)",
+                        (document_key,),
+                    )
+            except sqlite3.DatabaseError:
+                logger.exception(f"Could not index document: {document_key}")
+                self._recover()
+
+    def remove_document(self, document_key: str) -> None:
+        """Remove a document's rows from the index; never raises."""
+        with self._lock:
+            if not self.available:
+                return
+            assert self._conn is not None
+            try:
+                with self._conn:
+                    self._conn.execute(
+                        "DELETE FROM corpus WHERE document_key = ?", (document_key,)
+                    )
+                    self._conn.execute(
+                        "DELETE FROM indexed_documents WHERE document_key = ?",
+                        (document_key,),
+                    )
+            except sqlite3.DatabaseError:
+                logger.exception(f"Could not deindex document: {document_key}")
+                self._recover()
+
+    def indexed_keys(self) -> set[str]:
+        """Return the keys currently present in the index; never raises."""
+        with self._lock:
+            if not self.available:
+                return set()
+            assert self._conn is not None
+            try:
+                rows = self._conn.execute(
+                    "SELECT document_key FROM indexed_documents"
+                ).fetchall()
+            except sqlite3.DatabaseError:
+                logger.exception("Could not read indexed document keys")
+                self._recover()
+                return set()
+            return {row[0] for row in rows}
+
+    def search(
+        self,
+        query: str,
+        max_results: int,
+        document_keys: list[str] | None = None,
+    ) -> list[CorpusSearchHit]:
+        """Return ranked matches for a free-text query.
+
+        Raises RuntimeError when the index cannot serve searches because
+        SQLite FTS5 is unavailable or the index database cannot be opened.
+        """
+        with self._lock:
+            if not self.available:
+                raise RuntimeError(
+                    "Corpus search is unavailable: this Python's SQLite build "
+                    "lacks the FTS5 extension or the search index cannot be "
+                    "opened."
+                )
+            assert self._conn is not None
+
+            match = _fts_match_expression(query)
+            if not match:
+                return []
+            if document_keys is not None and len(document_keys) == 0:
+                return []
+
+            sql = (
+                "SELECT document_key, anchor, page, "
+                f"snippet(corpus, {_TEXT_COLUMN}, '', '', ' … ', 20) "
+                "FROM corpus WHERE corpus MATCH ?"
+            )
+            params: list[object] = [match]
+            if document_keys is not None:
+                placeholders = ", ".join("?" for _ in document_keys)
+                sql += f" AND document_key IN ({placeholders})"
+                params.extend(document_keys)
+            sql += " ORDER BY rank LIMIT ?"
+            params.append(max(0, max_results))
+
+            try:
+                rows = self._conn.execute(sql, params).fetchall()
+            except sqlite3.DatabaseError:
+                logger.exception("Corpus search failed; resetting the index")
+                self._recover()
+                return []
+
+            return [
+                CorpusSearchHit(
+                    document_key=row[0],
+                    anchor=row[1],
+                    page=int(row[2]) if row[2] is not None else None,
+                    snippet=row[3],
+                )
+                for row in rows
+            ]

--- a/docling_mcp/store/local.py
+++ b/docling_mcp/store/local.py
@@ -1,0 +1,317 @@
+"""Local document store implementations."""
+
+import json
+import os
+import re
+import threading
+import uuid
+from collections.abc import Iterator, MutableMapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypeGuard
+
+from docling_core.types.doc.document import DoclingDocument
+
+from docling_mcp.logger import setup_logger
+from docling_mcp.store.base import DocumentMetadata
+
+logger = setup_logger()
+
+_KEY_PATTERN = re.compile(r"[0-9a-f]{32}")
+_META_SUFFIX = ".meta.json"
+
+
+def is_valid_document_key(document_key: object) -> TypeGuard[str]:
+    """Return whether a value is a well-formed document key."""
+    return (
+        isinstance(document_key, str)
+        and _KEY_PATTERN.fullmatch(document_key) is not None
+    )
+
+
+class InMemoryDocumentStore(MutableMapping[str, DoclingDocument]):
+    """Document store keeping everything in process memory.
+
+    Preserves the pre-persistence behavior of the plain dict cache, with the
+    same key-format contract as the persistent store. Built on MutableMapping
+    so bulk operations such as update() and setdefault() also go through the
+    validating __setitem__.
+    """
+
+    def __init__(self) -> None:
+        self._documents: dict[str, DoclingDocument] = {}
+
+    def __setitem__(self, document_key: str, document: DoclingDocument) -> None:
+        """Store a document under a well-formed key."""
+        if not is_valid_document_key(document_key):
+            raise ValueError(f"Invalid document key: {document_key!r}")
+        self._documents[document_key] = document
+
+    def __getitem__(self, document_key: str) -> DoclingDocument:
+        """Return the document stored under a key."""
+        return self._documents[document_key]
+
+    def __delitem__(self, document_key: str) -> None:
+        """Remove a document."""
+        del self._documents[document_key]
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the stored document keys."""
+        return iter(self._documents)
+
+    def __len__(self) -> int:
+        """Return the number of stored documents."""
+        return len(self._documents)
+
+    def list_metadata(self) -> list[DocumentMetadata]:
+        """Return metadata records synthesized from the in-memory documents."""
+        return [
+            DocumentMetadata.from_document(key, doc, stored_at=None)
+            for key, doc in list(self._documents.items())
+        ]
+
+
+class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
+    """Document store persisting converted documents to a local directory.
+
+    Documents that carry a conversion origin are written through to disk as
+    DoclingDocument JSON with a metadata sidecar, so they survive server
+    restarts. Documents without an origin (in-progress authored documents)
+    stay memory-only.
+
+    Persisted documents are conversion artifacts: in-place edits made by
+    tools live in session memory only and are not written back under the
+    conversion key, so a cache hit always returns document state derived
+    from the converted source. Use the save/export tools to make edited
+    state durable.
+
+    Documents are never evicted from memory during a session, so object
+    identity is stable for as long as the process lives. Durability is best
+    effort: a failed write leaves any previous disk copy in place (same
+    content hash, so the same conversion) and is logged. Explicit deletion
+    is strict and raises when disk state cannot be removed. Concurrent
+    multi-process access is last-writer-wins; in-process access is guarded
+    by a lock. Keys are validated against the 32-hex key format before any
+    path is derived from them. The cache directory is created owner-only
+    and data files are written with owner-only permissions.
+    """
+
+    def __init__(self, cache_dir: Path) -> None:
+        self._dir = cache_dir
+        self._dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # mkdir(exist_ok=True) does not tighten a pre-existing directory
+        os.chmod(self._dir, 0o700)
+        # Probe writability now: mkdir(exist_ok=True) accepts an existing
+        # read-only directory, and the factory needs the failure at
+        # construction time to fall back to another location. Any OSError,
+        # including a failing unlink, propagates as "not writable".
+        probe = self._dir / f".probe-{os.getpid()}-{uuid.uuid4().hex}"
+        try:
+            probe.touch()
+        finally:
+            probe.unlink(missing_ok=True)
+        self._memory: dict[str, DoclingDocument] = {}
+        self._lock = threading.RLock()
+
+    def _doc_path(self, document_key: str) -> Path:
+        return self._dir / f"{document_key}.json"
+
+    def _meta_path(self, document_key: str) -> Path:
+        return self._dir / f"{document_key}{_META_SUFFIX}"
+
+    def _persist(self, document_key: str, document: DoclingDocument) -> None:
+        # Unique temp names keep concurrent same-key writers from clobbering
+        # each other's in-flight files; os.replace keeps readers consistent
+        # per file. The document/sidecar pair is not atomic as a pair: the
+        # sidecar is derived, advisory data and listings tolerate a missing
+        # or stale one.
+        token = f"{os.getpid()}-{uuid.uuid4().hex}"
+        doc_tmp = self._dir / f"{document_key}.{token}.doc.tmp"
+        meta_tmp = self._dir / f"{document_key}.{token}.meta.tmp"
+
+        try:
+            document.save_as_json(filename=doc_tmp)
+            os.chmod(doc_tmp, 0o600)
+            os.replace(doc_tmp, self._doc_path(document_key))
+
+            metadata = DocumentMetadata.from_document(
+                document_key,
+                document,
+                stored_at=datetime.now(timezone.utc).isoformat(),
+            )
+            meta_tmp.write_text(metadata.model_dump_json(), encoding="utf-8")
+            os.chmod(meta_tmp, 0o600)
+            os.replace(meta_tmp, self._meta_path(document_key))
+        finally:
+            for tmp in (doc_tmp, meta_tmp):
+                try:
+                    tmp.unlink(missing_ok=True)
+                except OSError:
+                    logger.warning(f"Could not remove temp file: {tmp}")
+
+    def _try_persist(self, document_key: str, document: DoclingDocument) -> None:
+        """Persist a document; on failure keep the memory copy authoritative.
+
+        Nothing is deleted on failure: under content-hash keys, any
+        pre-existing disk copy for the same key was produced from the same
+        source bytes and configuration, so it stays valid for restart-time
+        discovery. Losing durability is logged rather than raised.
+        Programming errors are not swallowed.
+        """
+        try:
+            self._persist(document_key, document)
+        except (OSError, ValueError, TypeError):
+            logger.exception(f"Failed to persist document: {document_key}")
+
+    def _drop_persisted(self, document_key: str) -> None:
+        """Remove disk state for a key, raising on the first failure."""
+        for path in (self._doc_path(document_key), self._meta_path(document_key)):
+            path.unlink(missing_ok=True)
+
+    def __setitem__(self, document_key: str, document: DoclingDocument) -> None:
+        """Store a document, persisting it when it has a conversion origin."""
+        if not is_valid_document_key(document_key):
+            raise ValueError(f"Invalid document key: {document_key!r}")
+
+        with self._lock:
+            if document.origin is not None:
+                self._memory[document_key] = document
+                self._try_persist(document_key, document)
+            else:
+                # Replacing a persisted document with a memory-only one must
+                # not let the old disk copy resurface after a restart; if the
+                # disk copy cannot be removed, fail the operation instead of
+                # succeeding in memory only.
+                self._drop_persisted(document_key)
+                self._memory[document_key] = document
+
+    def __getitem__(self, document_key: str) -> DoclingDocument:
+        """Return a document from memory or load it from disk.
+
+        Unreadable or corrupt disk entries behave like absent keys.
+        """
+        if not is_valid_document_key(document_key):
+            raise KeyError(document_key)
+
+        with self._lock:
+            if document_key in self._memory:
+                return self._memory[document_key]
+
+            doc_path = self._doc_path(document_key)
+            if doc_path.exists():
+                try:
+                    document = DoclingDocument.load_from_json(filename=doc_path)
+                except (OSError, ValueError) as exc:
+                    logger.warning(
+                        f"Unreadable document file for {document_key}: {exc}"
+                    )
+                    # Quarantine the corrupt entry so membership checks stop
+                    # reporting it and the source can be converted again.
+                    quarantine = self._dir / (
+                        f"{document_key}.corrupt-{os.getpid()}-{uuid.uuid4().hex}"
+                    )
+                    try:
+                        os.replace(doc_path, quarantine)
+                        logger.warning(f"Quarantined corrupt entry to: {quarantine}")
+                    except OSError:
+                        logger.warning(f"Could not quarantine: {doc_path}")
+                    raise KeyError(document_key) from exc
+                self._memory[document_key] = document
+                return document
+
+        raise KeyError(document_key)
+
+    def __delitem__(self, document_key: str) -> None:
+        """Remove a document from memory and disk.
+
+        Raises OSError when the disk copy cannot be removed, so deletion is
+        never silently incomplete.
+        """
+        if not is_valid_document_key(document_key):
+            raise KeyError(document_key)
+        with self._lock:
+            found = document_key in self
+            self._drop_persisted(document_key)
+            self._memory.pop(document_key, None)
+            if not found:
+                raise KeyError(document_key)
+
+    def __contains__(self, document_key: object) -> bool:
+        """Return whether a document exists in memory or on disk."""
+        if not is_valid_document_key(document_key):
+            return False
+        with self._lock:
+            return (
+                document_key in self._memory
+                or self._doc_path(document_key).exists()
+            )
+
+    def _disk_keys(self) -> list[str]:
+        keys = []
+        for path in self._dir.glob("*.json"):
+            if path.name.endswith(_META_SUFFIX):
+                continue
+            if _KEY_PATTERN.fullmatch(path.stem):
+                keys.append(path.stem)
+        return keys
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over all document keys in memory and on disk."""
+        with self._lock:
+            seen = set(self._memory.keys())
+            disk = [key for key in self._disk_keys() if key not in seen]
+        yield from seen
+        yield from disk
+
+    def __len__(self) -> int:
+        """Return the number of distinct documents in memory and on disk."""
+        with self._lock:
+            return len(set(self._memory.keys()) | set(self._disk_keys()))
+
+    def list_metadata(self) -> list[DocumentMetadata]:
+        """Return metadata for all stored documents.
+
+        In-memory documents are authoritative for their descriptive fields;
+        the persisted timestamp is taken from the sidecar when one exists.
+        A sidecar is only trusted when its embedded key matches its filename.
+        """
+        with self._lock:
+            records: dict[str, DocumentMetadata] = {}
+
+            for key in self._disk_keys():
+                stored_at = None
+                try:
+                    record = DocumentMetadata.model_validate(
+                        json.loads(self._meta_path(key).read_text(encoding="utf-8"))
+                    )
+                    if record.document_key == key:
+                        stored_at = record.stored_at
+                        records[key] = record
+                    else:
+                        logger.warning(f"Sidecar key mismatch for: {key}")
+                except (OSError, ValueError):
+                    logger.warning(f"Missing or invalid metadata sidecar for: {key}")
+                if key not in records:
+                    # The document file itself proves this is a persisted
+                    # document; fall back to its mtime so listings that
+                    # filter on persistence do not hide it.
+                    try:
+                        mtime = self._doc_path(key).stat().st_mtime
+                        stored_at = datetime.fromtimestamp(
+                            mtime, tz=timezone.utc
+                        ).isoformat()
+                    except OSError:
+                        stored_at = None
+                    records[key] = DocumentMetadata(
+                        document_key=key, stored_at=stored_at
+                    )
+
+            for key, doc in self._memory.items():
+                disk_stored_at = (
+                    records[key].stored_at if key in records else None
+                )
+                records[key] = DocumentMetadata.from_document(
+                    key, doc, stored_at=disk_stored_at
+                )
+
+            return sorted(records.values(), key=lambda r: r.document_key)

--- a/docling_mcp/store/local.py
+++ b/docling_mcp/store/local.py
@@ -13,12 +13,14 @@ from typing import TypeGuard
 from docling_core.types.doc.document import DoclingDocument
 
 from docling_mcp.logger import setup_logger
-from docling_mcp.store.base import DocumentMetadata
+from docling_mcp.store.base import CorpusSearchHit, DocumentMetadata
+from docling_mcp.store.index import CorpusIndex
 
 logger = setup_logger()
 
 _KEY_PATTERN = re.compile(r"[0-9a-f]{32}")
 _META_SUFFIX = ".meta.json"
+_INDEX_FILENAME = "corpus-index.sqlite3"
 
 
 def is_valid_document_key(document_key: object) -> TypeGuard[str]:
@@ -40,12 +42,19 @@ class InMemoryDocumentStore(MutableMapping[str, DoclingDocument]):
 
     def __init__(self) -> None:
         self._documents: dict[str, DoclingDocument] = {}
+        self._index = CorpusIndex(db_path=None)
 
     def __setitem__(self, document_key: str, document: DoclingDocument) -> None:
         """Store a document under a well-formed key."""
         if not is_valid_document_key(document_key):
             raise ValueError(f"Invalid document key: {document_key!r}")
         self._documents[document_key] = document
+        # Only conversion artifacts are searchable; replacing one with an
+        # in-progress authored document also drops its stale index rows.
+        if document.origin is not None:
+            self._index.index_document(document_key, document)
+        else:
+            self._index.remove_document(document_key)
 
     def __getitem__(self, document_key: str) -> DoclingDocument:
         """Return the document stored under a key."""
@@ -54,6 +63,7 @@ class InMemoryDocumentStore(MutableMapping[str, DoclingDocument]):
     def __delitem__(self, document_key: str) -> None:
         """Remove a document."""
         del self._documents[document_key]
+        self._index.remove_document(document_key)
 
     def __iter__(self) -> Iterator[str]:
         """Iterate over the stored document keys."""
@@ -70,6 +80,15 @@ class InMemoryDocumentStore(MutableMapping[str, DoclingDocument]):
             for key, doc in list(self._documents.items())
         ]
 
+    def search_corpus(
+        self,
+        query: str,
+        max_results: int,
+        document_keys: list[str] | None = None,
+    ) -> list[CorpusSearchHit]:
+        """Return ranked lexical matches across the stored documents."""
+        return self._index.search(query, max_results, document_keys)
+
 
 class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
     """Document store persisting converted documents to a local directory.
@@ -83,7 +102,9 @@ class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
     tools live in session memory only and are not written back under the
     conversion key, so a cache hit always returns document state derived
     from the converted source. Use the save/export tools to make edited
-    state durable.
+    state durable. A lexical search index derived from the conversion
+    artifacts lives beside the document files and is reconciled with them
+    on every search, so it can always be rebuilt from disk.
 
     Documents are never evicted from memory during a session, so object
     identity is stable for as long as the process lives. Durability is best
@@ -112,6 +133,7 @@ class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
             probe.unlink(missing_ok=True)
         self._memory: dict[str, DoclingDocument] = {}
         self._lock = threading.RLock()
+        self._index = CorpusIndex(db_path=self._dir / _INDEX_FILENAME)
 
     def _doc_path(self, document_key: str) -> Path:
         return self._dir / f"{document_key}.json"
@@ -177,6 +199,7 @@ class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
             if document.origin is not None:
                 self._memory[document_key] = document
                 self._try_persist(document_key, document)
+                self._index.index_document(document_key, document)
             else:
                 # Replacing a persisted document with a memory-only one must
                 # not let the old disk copy resurface after a restart; if the
@@ -184,6 +207,7 @@ class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
                 # succeeding in memory only.
                 self._drop_persisted(document_key)
                 self._memory[document_key] = document
+                self._index.remove_document(document_key)
 
     def __getitem__(self, document_key: str) -> DoclingDocument:
         """Return a document from memory or load it from disk.
@@ -233,6 +257,7 @@ class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
             found = document_key in self
             self._drop_persisted(document_key)
             self._memory.pop(document_key, None)
+            self._index.remove_document(document_key)
             if not found:
                 raise KeyError(document_key)
 
@@ -241,10 +266,7 @@ class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
         if not is_valid_document_key(document_key):
             return False
         with self._lock:
-            return (
-                document_key in self._memory
-                or self._doc_path(document_key).exists()
-            )
+            return document_key in self._memory or self._doc_path(document_key).exists()
 
     def _disk_keys(self) -> list[str]:
         keys = []
@@ -307,11 +329,53 @@ class LocalDocumentStore(MutableMapping[str, DoclingDocument]):
                     )
 
             for key, doc in self._memory.items():
-                disk_stored_at = (
-                    records[key].stored_at if key in records else None
-                )
+                disk_stored_at = records[key].stored_at if key in records else None
                 records[key] = DocumentMetadata.from_document(
                     key, doc, stored_at=disk_stored_at
                 )
 
             return sorted(records.values(), key=lambda r: r.document_key)
+
+    def _sync_index(self) -> None:
+        """Reconcile the search index with the stored conversion artifacts.
+
+        Rebuilds any missing entries (a deleted or freshly recreated index
+        database) and drops entries whose document no longer exists, so the
+        index is always derivable from the store. Documents only on disk are
+        loaded transiently for indexing without pinning them in memory.
+        """
+        indexed = self._index.indexed_keys()
+        current: dict[str, DoclingDocument | None] = {
+            key: doc for key, doc in self._memory.items() if doc.origin is not None
+        }
+        for key in self._disk_keys():
+            current.setdefault(key, None)
+
+        for key in indexed - set(current):
+            self._index.remove_document(key)
+
+        for key, doc in current.items():
+            if key in indexed:
+                continue
+            if doc is None:
+                try:
+                    doc = DoclingDocument.load_from_json(filename=self._doc_path(key))
+                except (OSError, ValueError) as exc:
+                    logger.warning(f"Could not index document {key}: {exc}")
+                    continue
+            self._index.index_document(key, doc)
+
+    def search_corpus(
+        self,
+        query: str,
+        max_results: int,
+        document_keys: list[str] | None = None,
+    ) -> list[CorpusSearchHit]:
+        """Return ranked lexical matches across the stored documents.
+
+        The index reflects immutable conversion artifacts: session-only tool
+        edits are not searchable, matching what a restart would serve.
+        """
+        with self._lock:
+            self._sync_index()
+            return self._index.search(query, max_results, document_keys)

--- a/docling_mcp/tools/conversion.py
+++ b/docling_mcp/tools/conversion.py
@@ -62,7 +62,13 @@ def is_document_in_local_cache(
 def convert_document_into_docling_document(
     source: Annotated[
         str,
-        Field(description="The URL or local file path to the document."),
+        Field(
+            description=(
+                "The URL or local file path to the document. Object-storage "
+                "URIs (s3://, gs://, abfs://) are supported when the "
+                "matching provider extra is installed."
+            )
+        ),
     ],
 ) -> ConversionOutput:
     """Convert a document of any type from a URL or local path and store in local cache.

--- a/docling_mcp/tools/converters/local.py
+++ b/docling_mcp/tools/converters/local.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from docling_core.types.doc.common.content_layer import ContentLayer
 from docling_core.types.doc.labels import DocItemLabel
 
-from docling_mcp.docling_cache import get_cache_key
+from docling_mcp.docling_cache import get_cache_key, local_conversion_context
 from docling_mcp.logger import setup_logger
 from docling_mcp.settings.conversion import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
@@ -67,7 +67,7 @@ class LocalDocumentConverter:
         source = source.strip("\"'")
         logger.info(f"Converting document locally: {source}")
 
-        cache_key = get_cache_key(source)
+        cache_key = get_cache_key(source, conversion=local_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")
@@ -88,15 +88,15 @@ class LocalDocumentConverter:
         if has_error:
             raise Exception(f"Local conversion failed: {result.errors}")
 
-        # Cache the result
-        local_document_cache[cache_key] = result.document
-
-        # Add source metadata
+        # Add source metadata before caching so the persisted document is complete
         item = result.document.add_text(
             label=DocItemLabel.TEXT,
             text=f"source: {source}",
             content_layer=ContentLayer.FURNITURE,
         )
+
+        # Cache the result
+        local_document_cache[cache_key] = result.document
         local_stack_cache[cache_key] = [item]
 
         logger.info(f"Successfully converted document: {cache_key}")

--- a/docling_mcp/tools/converters/local.py
+++ b/docling_mcp/tools/converters/local.py
@@ -11,6 +11,7 @@ from docling_mcp.settings.conversion import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
 
 from .base import ConversionOutput
+from .sources import fetched_source
 
 # Import DocumentConverter only if available
 try:
@@ -67,7 +68,12 @@ class LocalDocumentConverter:
         source = source.strip("\"'")
         logger.info(f"Converting document locally: {source}")
 
-        cache_key = get_cache_key(source, conversion=local_conversion_context())
+        with fetched_source(source) as local_source:
+            return self._convert_local_source(source, local_source)
+
+    def _convert_local_source(self, source: str, local_source: str) -> ConversionOutput:
+        """Convert a locally readable source, recording the original source."""
+        cache_key = get_cache_key(local_source, conversion=local_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")
@@ -75,7 +81,7 @@ class LocalDocumentConverter:
 
         # Get converter and convert
         converter = self._get_converter()
-        result = converter.convert(source)
+        result = converter.convert(local_source)
 
         # Check for errors
         has_error = False

--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -14,6 +14,7 @@ from docling_mcp.settings.service_client import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
 
 from .base import ConversionOutput
+from .sources import fetched_source
 
 logger = setup_logger()
 
@@ -45,7 +46,12 @@ class RemoteDocumentConverter:
         source = source.strip("\"'")
         logger.info(f"Converting document via remote API: {source}")
 
-        cache_key = get_cache_key(source, conversion=remote_conversion_context())
+        with fetched_source(source) as local_source:
+            return self._convert_local_source(source, local_source)
+
+    def _convert_local_source(self, source: str, local_source: str) -> ConversionOutput:
+        """Convert a locally readable source, recording the original source."""
+        cache_key = get_cache_key(local_source, conversion=remote_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")
@@ -62,7 +68,7 @@ class RemoteDocumentConverter:
         )
 
         # Convert via remote API
-        result = self.client.convert(source=source, options=options)
+        result = self.client.convert(source=local_source, options=options)
 
         # Check for errors
         if hasattr(result, "status") and hasattr(result.status, "is_error"):

--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -8,7 +8,7 @@ from docling.service_client import DoclingServiceClient
 from docling_core.types.doc.common.content_layer import ContentLayer
 from docling_core.types.doc.labels import DocItemLabel
 
-from docling_mcp.docling_cache import get_cache_key
+from docling_mcp.docling_cache import get_cache_key, remote_conversion_context
 from docling_mcp.logger import setup_logger
 from docling_mcp.settings.service_client import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
@@ -45,7 +45,7 @@ class RemoteDocumentConverter:
         source = source.strip("\"'")
         logger.info(f"Converting document via remote API: {source}")
 
-        cache_key = get_cache_key(source)
+        cache_key = get_cache_key(source, conversion=remote_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")
@@ -69,15 +69,15 @@ class RemoteDocumentConverter:
             if result.status.is_error:
                 raise Exception(f"Remote conversion failed: {result.errors}")
 
-        # Cache the result
-        local_document_cache[cache_key] = result.document
-
-        # Add source metadata
+        # Add source metadata before caching so the persisted document is complete
         item = result.document.add_text(
             label=DocItemLabel.TEXT,
             text=f"source: {source}",
             content_layer=ContentLayer.FURNITURE,
         )
+
+        # Cache the result
+        local_document_cache[cache_key] = result.document
         local_stack_cache[cache_key] = [item]
 
         logger.info(f"Successfully converted document: {cache_key}")

--- a/docling_mcp/tools/converters/sources.py
+++ b/docling_mcp/tools/converters/sources.py
@@ -1,0 +1,86 @@
+"""Fetch-to-temp resolution of object-storage source URIs."""
+
+import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlsplit
+
+from docling_mcp.logger import setup_logger
+
+logger = setup_logger()
+
+# Object-storage schemes resolved through fsspec, mapped to the provider
+# package implementing them and the docling-mcp extra that installs it.
+# IBM Cloud Object Storage is reached through the S3 protocol.
+_FSSPEC_SCHEMES: dict[str, tuple[str, str]] = {
+    "s3": ("s3fs", "s3"),
+    "gs": ("gcsfs", "gcs"),
+    "gcs": ("gcsfs", "gcs"),
+    "abfs": ("adlfs", "azure"),
+    "az": ("adlfs", "azure"),
+}
+
+_COPY_BUFFER_SIZE = 1 << 20
+
+
+def _install_hint(scheme: str, package: str, extra: str) -> str:
+    return (
+        f"Reading {scheme}:// sources requires the '{package}' package. "
+        f"Install it with the docling-mcp[{extra}] extra."
+    )
+
+
+@contextmanager
+def fetched_source(source: str) -> Iterator[str]:
+    """Yield a local path for a source, fetching object-storage URIs.
+
+    Sources with an fsspec-style object-storage scheme (s3://, gs://,
+    abfs://) are downloaded to a temporary file that is removed when the
+    context exits; the file keeps the URI's suffix so input-format detection
+    and content-hash cache keys behave exactly as for a local file. Any
+    other source is yielded unchanged.
+
+    Credentials are resolved by the provider's standard chain (environment
+    variables, configuration files, instance roles). They are deliberately
+    never read from MCP client configuration, which several clients store in
+    plaintext.
+
+    Args:
+        source: A local path, URL, or object-storage URI.
+
+    Yields:
+        A local filesystem path for object-storage URIs, otherwise the
+        source unchanged.
+
+    Raises:
+        ValueError: When the provider package for the URI scheme is not
+            installed.
+    """
+    scheme = urlsplit(source).scheme.lower()
+    if scheme not in _FSSPEC_SCHEMES:
+        yield source
+        return
+
+    package, extra = _FSSPEC_SCHEMES[scheme]
+    try:
+        import fsspec
+    except ImportError as exc:
+        raise ValueError(_install_hint(scheme, package, extra)) from exc
+
+    suffix = PurePosixPath(urlsplit(source).path).suffix
+    handle = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    tmp_path = Path(handle.name)
+    try:
+        try:
+            with fsspec.open(source, "rb") as remote_file:
+                shutil.copyfileobj(remote_file, handle, _COPY_BUFFER_SIZE)
+        except ImportError as exc:
+            raise ValueError(_install_hint(scheme, package, extra)) from exc
+        finally:
+            handle.close()
+        logger.info(f"Fetched object-storage source to {tmp_path}: {source}")
+        yield str(tmp_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/docling_mcp/tools/corpus.py
+++ b/docling_mcp/tools/corpus.py
@@ -8,6 +8,7 @@ from pydantic import Field
 
 from docling_mcp.logger import setup_logger
 from docling_mcp.shared import local_document_cache, mcp
+from docling_mcp.store.local import is_valid_document_key
 
 # Create a default project logger
 logger = setup_logger()
@@ -67,4 +68,103 @@ def list_converted_documents() -> list[ConvertedDocumentInfo]:
         )
         for record in local_document_cache.list_metadata()
         if record.source_filename is not None or record.stored_at is not None
+    ]
+
+
+@dataclass
+class CorpusSearchResult:
+    """One ranked match from a search across the converted documents."""
+
+    document_key: Annotated[
+        str,
+        Field(description="The unique identifier of the document in the local cache."),
+    ]
+    anchor: Annotated[
+        str,
+        Field(
+            description=(
+                "The anchor reference of the matching document item, usable "
+                "with the manipulation tools."
+            ),
+            examples=["#/texts/2"],
+        ),
+    ]
+    snippet: Annotated[
+        str,
+        Field(description="A short text excerpt around the match."),
+    ]
+    page: Annotated[
+        int | None,
+        Field(
+            description=(
+                "The page number the matching item appears on, or null when "
+                "the document has no page provenance."
+            )
+        ),
+    ]
+
+
+@mcp.tool(
+    title="Search across documents",
+    structured_output=True,
+    annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+)
+def search_across_documents(
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "The text to search for. Matching is case-insensitive and "
+                "word-based; every word in the query must appear in a "
+                "matching item."
+            )
+        ),
+    ],
+    max_results: Annotated[
+        int,
+        Field(
+            ge=1,
+            le=100,
+            description="The maximum number of hits to return.",
+        ),
+    ] = 10,
+    document_keys: Annotated[
+        list[str] | None,
+        Field(
+            description=(
+                "Restrict the search to these document keys, as returned by "
+                "list_converted_documents. Searches all converted documents "
+                "when omitted."
+            )
+        ),
+    ] = None,
+) -> list[CorpusSearchResult]:
+    """Search for text across all converted documents in the local cache.
+
+    This tool returns ranked hits, each carrying the document key, the anchor
+    of the matching item, a snippet of the matching text, and the page number
+    when the document has page provenance. Pass the anchor to
+    get_text_of_document_item_at_anchor to read the full item, and cite the
+    document and page from the hit. The search covers converted documents,
+    including documents persisted by earlier server sessions; in-progress
+    authored documents are not searched.
+    """
+    if not query.strip():
+        raise ValueError("The search query must not be empty.")
+    if document_keys is not None:
+        for key in document_keys:
+            if not is_valid_document_key(key):
+                raise ValueError(f"Invalid document key: {key!r}")
+
+    hits = local_document_cache.search_corpus(
+        query, max_results=max_results, document_keys=document_keys
+    )
+    return [
+        CorpusSearchResult(
+            document_key=hit.document_key,
+            anchor=hit.anchor,
+            snippet=hit.snippet,
+            page=hit.page,
+        )
+        for hit in hits
     ]

--- a/docling_mcp/tools/corpus.py
+++ b/docling_mcp/tools/corpus.py
@@ -1,0 +1,70 @@
+"""Tools for working with the collection of stored documents."""
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from docling_mcp.logger import setup_logger
+from docling_mcp.shared import local_document_cache, mcp
+
+# Create a default project logger
+logger = setup_logger()
+
+
+@dataclass
+class ConvertedDocumentInfo:
+    """Description of one converted document available in the local cache."""
+
+    document_key: Annotated[
+        str,
+        Field(description="The unique identifier of the document in the local cache."),
+    ]
+    name: Annotated[
+        str | None,
+        Field(description="The document name, if available."),
+    ]
+    source_filename: Annotated[
+        str | None,
+        Field(description="The filename of the original source."),
+    ]
+    num_pages: Annotated[
+        int,
+        Field(description="The number of pages, or 0 when not applicable."),
+    ]
+    stored_at: Annotated[
+        str | None,
+        Field(
+            description=(
+                "UTC timestamp when the document was persisted, or null when "
+                "it has not been persisted."
+            )
+        ),
+    ]
+
+
+@mcp.tool(
+    title="List converted documents",
+    structured_output=True,
+    annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+)
+def list_converted_documents() -> list[ConvertedDocumentInfo]:
+    """List all converted documents available in the local cache.
+
+    This tool returns one entry per converted document, including documents
+    persisted by earlier server sessions. In-progress authored documents are
+    not listed. Use the returned document_key with the manipulation and export
+    tools instead of re-converting a source.
+    """
+    return [
+        ConvertedDocumentInfo(
+            document_key=record.document_key,
+            name=record.name,
+            source_filename=record.source_filename,
+            num_pages=record.num_pages,
+            stored_at=record.stored_at,
+        )
+        for record in local_document_cache.list_metadata()
+        if record.source_filename is not None or record.stored_at is not None
+    ]

--- a/docling_mcp/tools/generation.py
+++ b/docling_mcp/tools/generation.py
@@ -136,7 +136,7 @@ class SaveDocumentOutput:
 
 @mcp.tool(
     title="Save Docling document",
-    annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
 )
 def save_docling_document(
     document_key: Annotated[

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -9,6 +9,11 @@ Docling MCP can be easily integrated into MCP-compatible clients using standard 
 Once installed, extend Claude for Desktop so that it can read from your computer's file system, by following the [For Claude Desktop Users](https://modelcontextprotocol.io/quickstart/user) tutorial.
 
 
+## IBM Bob
+
+[IBM Bob](https://bob.ibm.com) reads MCP servers from a global configuration or a project-level `.bob/mcp.json` file. Both local conversion and delegation to a docling-serve endpoint are supported. See the dedicated [integration guide](bob.md) for the setup, example configurations, and a skill that makes Bob convert documents with Docling before working on them.
+
+
 ## LM Studio
 
 [LM Studio](https://lmstudio.ai/) supports MCP tools and allows to run your agentic workloads completely locally. The configuration is done by editing the `mcp.json` file, or with the convenience button below.

--- a/docs/integrations/bob.md
+++ b/docs/integrations/bob.md
@@ -1,0 +1,154 @@
+# IBM Bob
+
+[IBM Bob](https://bob.ibm.com) is IBM's agentic SDLC tool, available as Bob IDE and Bob Shell. Both read MCP server definitions from JSON configuration files, so Docling MCP plugs in with a single `mcpServers` entry.
+
+The server process always runs on your machine over stdio. The `DOCLING_CONVERSION_MODE` environment variable decides where document conversion happens: `local` converts in-process, `remote` delegates conversion to a [docling-serve](https://github.com/docling-project/docling-serve) endpoint.
+
+## Prerequisites
+
+- Bob IDE or Bob Shell.
+- [uv](https://docs.astral.sh/uv/) on your `PATH`. The examples launch the server with `uvx`.
+- Local mode: Python 3.10 or later available to uv, plus disk space for the Docling models downloaded on first conversion.
+- Remote mode: a reachable docling-serve endpoint, and an API key if the endpoint requires one.
+
+## Configuration placement
+
+Bob merges MCP servers from two levels:
+
+- **Global**: `~/.bob/settings/mcp.json`, applied to every workspace. Open the Bob panel and select the **MCP** tab to edit it. Bob releases before 2.0.0 used `~/.bob/mcp_settings.json`; Bob migrates that file automatically.
+- **Project**: `.bob/mcp.json` in the project root. Bob creates the file if it does not exist. Commit it to share the setup with your team.
+
+When the same server name exists at both levels, the project entry takes precedence.
+
+## Local mode
+
+Add this to your global configuration or to `.bob/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "docling": {
+      "command": "uvx",
+      "args": [
+        "--from=docling-mcp[local]==2.1.0",
+        "docling-mcp-server",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "DOCLING_CONVERSION_MODE": "local"
+      }
+    }
+  }
+}
+```
+
+Two details matter here:
+
+- `--transport stdio` is required. Since v2 the server defaults to `streamable-http`, which Bob's stdio transport cannot talk to.
+- The `[local]` extra is required. The base package ships without the conversion models support, and `DOCLING_CONVERSION_MODE=local` fails with an `ImportError` if the extra is missing.
+
+## Remote mode
+
+Conversion runs on a docling-serve endpoint instead of your machine, so the base package is enough:
+
+```json
+{
+  "mcpServers": {
+    "docling": {
+      "command": "uvx",
+      "args": [
+        "--from=docling-mcp==2.1.0",
+        "docling-mcp-server",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "DOCLING_CONVERSION_MODE": "remote",
+        "DOCLING_SERVICE_URL": "https://your-docling-serve.example.com"
+      }
+    }
+  }
+}
+```
+
+`remote` is the default conversion mode; it is set explicitly here for clarity. If your endpoint enforces authentication, add `"DOCLING_SERVICE_API_KEY": "<your-key>"` to the `env` block. Bob stores `env` values literally and does not expand `${VAR}` references, so a key in a committed project `.bob/mcp.json` is exposed verbatim. Keep the credentialed entry in your global configuration instead.
+
+One more environment variable is honored in remote mode: set `DOCLING_FALLBACK_TO_LOCAL=true` to fall back to local conversion when the endpoint is unreachable. The fallback requires the `[local]` extra. The settings module also defines `DOCLING_SERVICE_TIMEOUT` and `DOCLING_SERVICE_MAX_RETRIES`, but in 2.1.0 they are not passed through to the docling-serve client, which uses a fixed 300 second job timeout and 3 HTTP retries.
+
+## Verify the setup
+
+Save the configuration and open the **MCP** tab in the Bob panel. A server named `docling` should appear. Expanding it lists 19 tools with the default tool groups:
+
+- Conversion: `convert_document_into_docling_document`, `convert_directory_files_into_docling_document`, `is_document_in_local_cache`
+- Generation: `create_new_docling_document`, `export_docling_document_to_markdown`, `save_docling_document`, `page_thumbnail`, plus the `add_*`, `open_list_*`, and `close_list_*` authoring tools
+- Manipulation: `get_overview_of_document_anchors`, `search_for_text_in_document_anchors`, `get_text_of_document_item_at_anchor`, `update_text_of_document_item_at_anchor`, `delete_document_items_at_anchors`
+
+The server also publishes seven MCP prompts, such as `convert_and_summarize`, which Bob surfaces as commands alongside its built-in ones.
+
+Then try a conversion with any PDF in your workspace:
+
+```prompt
+Convert /path/to/spec.pdf to a DoclingDocument and return its document-key.
+```
+
+Bob asks for approval to run `convert_document_into_docling_document` (see [Tool approval prompts](#every-tool-call-asks-for-approval)) and the tool returns:
+
+```json
+{
+  "from_cache": false,
+  "document_key": "<32-character hex key>"
+}
+```
+
+The `document_key` is a hash derived from the exact source string, so it differs between machines and between relative and absolute paths. Repeating the prompt returns `"from_cache": true` with the same key. The manipulation and export tools accept the key, so Bob can summarize, search, or edit the document without pasting its full text into the conversation. The cache lives in the server process memory; if Bob restarts the server, convert the document again. If the tool reports that the file cannot be found, pass an absolute path (see [Troubleshooting](#the-server-cannot-find-a-file-you-referenced)).
+
+## Troubleshooting
+
+### First conversion in local mode is slow or times out
+
+On first use, `uvx` resolves and installs the pinned package, and Docling downloads its conversion models during the first conversion. Bob's per-server timeout defaults to 60000 ms (1 minute); it accepts values up to 3600000 and snaps them to fixed steps (5 s, 10 s, 30 s, 1, 2, 5, 10, 30, and 60 minutes). Add for example `"timeout": 600000` to the `docling` server entry before the first run, or warm the package cache outside Bob first:
+
+```sh
+uvx --from='docling-mcp[local]==2.1.0' docling-mcp-server --help
+```
+
+The model download still happens on the first conversion, so expect that one call to take several minutes. Later conversions reuse the cached models.
+
+### Large PDFs exceed the tool timeout
+
+Raise the `timeout` value on the `docling` server entry, for example to `300000` (5 minutes). In remote mode the docling-serve request additionally has a fixed 300 second job timeout in docling-mcp 2.1.0, independent of Bob's setting. For scanned documents, OCR dominates the conversion time. Prefer converting one large file per tool call rather than pointing `convert_directory_files_into_docling_document` at a directory of large files.
+
+### The server cannot find a file you referenced
+
+The MCP server is a separate process. Bob spawns stdio servers with only the configured `command`, `args`, and `env`, so the server inherits Bob's own working directory, not the workspace root. Use absolute paths in prompts. This applies to remote mode as well: local files are read by the server process on your machine before conversion is delegated.
+
+### `uvx` is not found
+
+Bob IDE launched from the desktop may not inherit your shell `PATH`. Replace `"command": "uvx"` with the absolute path printed by `which uvx`.
+
+### Every tool call asks for approval
+
+That is Bob's default for MCP tools. To pre-approve specific tools, add them to the server's `alwaysAllow` array, for example `"alwaysAllow": ["is_document_in_local_cache", "export_docling_document_to_markdown"]`, or toggle auto-approval per tool from the server's entry in the MCP tab. The related `disabledTools` array hides individual tools from Bob entirely.
+
+## Bob skill
+
+A ready-made skill in [bob/skill/](bob/skill/) teaches Bob to reach for Docling whenever a task references a PDF, DOCX, PPTX, or scanned document: convert first, then work from the structured output by `document-key` instead of pasting raw text.
+
+Install it by copying the folder to `.bob/skills/docling/` in your workspace, or to `~/.bob/skills/docling/` to make it available everywhere:
+
+```sh
+mkdir -p .bob/skills/docling
+cp docs/integrations/bob/skill/SKILL.md .bob/skills/docling/
+```
+
+Bob watches its skills directories and picks up new or edited skills without a restart. When a request matches the skill's `description`, Bob activates it through its `use_skill` tool, asking for approval unless skills are auto-approved in the settings. Skills are available in every mode by default; an optional `groups` frontmatter field restricts a skill to specific modes.
+
+## Example configurations
+
+Ready-to-commit variants of the configuration above, one file per mode, are provided in [bob/](bob/):
+
+- [bob/mcp.local.json](bob/mcp.local.json)
+- [bob/mcp.remote.json](bob/mcp.remote.json)
+
+Copy the one you need to `.bob/mcp.json` in your project, or merge its `docling` entry into your global configuration. The remote variant deliberately omits `DOCLING_SERVICE_API_KEY`; if your endpoint needs one, add it to your global configuration rather than the committed project file.

--- a/docs/integrations/bob/mcp.local.json
+++ b/docs/integrations/bob/mcp.local.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "docling": {
+      "command": "uvx",
+      "args": [
+        "--from=docling-mcp[local]==2.1.0",
+        "docling-mcp-server",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "DOCLING_CONVERSION_MODE": "local"
+      }
+    }
+  }
+}

--- a/docs/integrations/bob/mcp.remote.json
+++ b/docs/integrations/bob/mcp.remote.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "docling": {
+      "command": "uvx",
+      "args": [
+        "--from=docling-mcp==2.1.0",
+        "docling-mcp-server",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "DOCLING_CONVERSION_MODE": "remote",
+        "DOCLING_SERVICE_URL": "https://your-docling-serve.example.com"
+      }
+    }
+  }
+}

--- a/docs/integrations/bob/skill/SKILL.md
+++ b/docs/integrations/bob/skill/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: docling
+description: Convert PDF, DOCX, PPTX, XLSX, HTML, and scanned or image-based documents into structured DoclingDocuments with the Docling MCP tools before working with their content. Activate whenever the user references a document file or asks to read, summarize, compare, extract from, or edit one.
+---
+
+# Docling-first document handling
+
+The `docling` MCP server converts documents into DoclingDocument, a structured format held in the server's cache and addressed by a `document_key`. Work from that structured output. Do not read document files directly or paste raw document text into the conversation.
+
+This skill requires the `docling` MCP server from the workspace or global MCP configuration. If its tools are not available, stop and tell the user to set it up first, following https://github.com/docling-project/docling-mcp/blob/main/docs/integrations/bob.md.
+
+## When to use this workflow
+
+Use it whenever a task involves a PDF, DOCX, PPTX, XLSX, or HTML file, a scanned document, or an image of a page. Typical signals: the user names a file with one of those extensions, points at a directory of documents, or asks about the content of a report, paper, spec, or contract.
+
+## Workflow
+
+1. Convert first. Call `convert_document_into_docling_document` with the file's absolute path or URL. For a directory of documents, call `convert_directory_files_into_docling_document` once instead of converting file by file.
+2. Record the returned `document_key`. A result with `"from_cache": true` means the document was already converted; reuse the key.
+3. Inspect structure before reading content. `get_overview_of_document_anchors` returns the document outline with an anchor per item. Use it to locate the relevant sections.
+4. Read selectively. `get_text_of_document_item_at_anchor` returns the text of a single item, and `search_for_text_in_document_anchors` finds anchors matching a search string. Only call `export_docling_document_to_markdown` when the task genuinely needs the full text.
+5. When asked to change content, edit through anchors with `update_text_of_document_item_at_anchor` or `delete_document_items_at_anchors`, then persist with `save_docling_document`.
+
+## Rules
+
+- Refer to converted documents by `document_key` in every follow-up tool call.
+- Quote only the document items needed to answer, and name the anchor they came from. Never paste large verbatim excerpts into the conversation.
+- Use absolute file paths. Relative paths resolve against the MCP server process, not the Bob workspace.
+- The document cache lives in server memory. If a `document_key` stops resolving after the server restarts, convert the source again.
+- Conversion of large or scanned files can take minutes. If a conversion call times out, ask the user to raise Bob's MCP network timeout instead of retrying in a loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,15 @@ smolagents = [
 mellea = [
     "mellea~=0.3",
 ]
+s3 = [
+    "s3fs>=2024.9.0",
+]
+gcs = [
+    "gcsfs>=2024.9.0",
+]
+azure = [
+    "adlfs>=2024.7.0",
+]
 
 [dependency-groups]
 dev = [
@@ -205,6 +214,7 @@ module = [
     "requests.*",
     "transformers.*",
     "llama_stack_client.*",  # needed since this will be there only on python>=3.12
+    "fsspec.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 """Define configuration options across tests."""
 
 import os
+import sys
+
+# Keep tests hermetic: use the in-memory document store so persisted documents
+# from earlier runs cannot change conversion results. Set unconditionally,
+# before any docling_mcp import, so an inherited environment cannot leak the
+# real persistent cache into test runs.
+os.environ["DOCLING_MCP_CACHE_PERSIST"] = "false"
 from collections.abc import AsyncGenerator
 from contextlib import AsyncExitStack
 from typing import Any
@@ -33,7 +40,7 @@ class MCPClient:
         # Explicitly use STDIO transport for tests (server default is now streamable-http)
         # Run as module instead of script to ensure proper Typer CLI initialization
         server_params = StdioServerParameters(
-            command="python",
+            command=sys.executable,
             args=["-m", "docling_mcp.servers.mcp_server", "--transport", "stdio"],
             env=test_env,
         )
@@ -79,4 +86,8 @@ async def mcp_client() -> AsyncGenerator[Any, Any]:
     client = MCPClient()
     await client.connect_to_server("docling_mcp/servers/mcp_server.py")
     yield client
+    # Intentionally not awaited: the MCP stdio client's anyio cancel scopes
+    # are entered across tasks under pytest-asyncio, and closing the stack
+    # here raises "Attempted to exit cancel scope in a different task".
+    # Leaked subprocesses are reaped when the pytest process exits.
     # await client.cleanup()

--- a/tests/data/gt_search_results.json
+++ b/tests/data/gt_search_results.json
@@ -8,7 +8,7 @@
     "No exact text matches were found. Found individual keyword matches in the following anchors:\n[anchor:#/texts/0] keyword matches (4 total): porttitor (2 occurrences), varius (2 occurrences)\n[anchor:#/texts/2] keyword matches (1 total): porttitor (1 occurrences)"
   ],
   "no_match": [
-    "No exact text matches nor individual keyword matches found for 'Banana Peel' in document with key test_doc_1.",
-    "No exact text matches nor individual keyword matches found for 'Banana Peel' in document with key test_doc_2."
+    "No exact text matches nor individual keyword matches found for 'Banana Peel' in document with key 11111111111111111111111111111111.",
+    "No exact text matches nor individual keyword matches found for 'Banana Peel' in document with key 22222222222222222222222222222222."
   ]
 }

--- a/tests/test_corpus_search.py
+++ b/tests/test_corpus_search.py
@@ -1,0 +1,276 @@
+"""Test lexical search across the stored document corpus."""
+
+from pathlib import Path
+
+import pytest
+
+from docling_core.types.doc.base import BoundingBox
+from docling_core.types.doc.common.origin import DocumentOrigin
+from docling_core.types.doc.common.reference import ProvenanceItem
+from docling_core.types.doc.document import DoclingDocument
+from docling_core.types.doc.items.table.table_data import TableCell, TableData
+from docling_core.types.doc.labels import DocItemLabel
+
+from docling_mcp.store.local import InMemoryDocumentStore, LocalDocumentStore
+
+KEY_A = "a" * 32
+KEY_B = "b" * 32
+
+_INDEX_FILENAME = "corpus-index.sqlite3"
+
+
+def _prov(page: int, length: int) -> ProvenanceItem:
+    return ProvenanceItem(
+        page_no=page,
+        bbox=BoundingBox(l=0.0, t=0.0, r=1.0, b=1.0),
+        charspan=(0, length),
+    )
+
+
+def make_corpus_document(
+    name: str, entries: list[tuple[str, int]], converted: bool = True
+) -> DoclingDocument:
+    """Build a document whose text items carry page provenance."""
+    doc = DoclingDocument(name=name)
+    if converted:
+        doc.origin = DocumentOrigin(
+            mimetype="application/pdf",
+            binary_hash=hash(name) & 0xFFFFFFFF,
+            filename=f"{name}.pdf",
+        )
+    for text, page in entries:
+        doc.add_text(label=DocItemLabel.TEXT, text=text, prov=_prov(page, len(text)))
+    return doc
+
+
+def test_search_returns_anchor_page_and_snippet(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    doc = make_corpus_document(
+        "doc-a",
+        [
+            ("The flux capacitor requires 1.21 gigawatts of power.", 3),
+            ("Unrelated prose about gardening tools.", 5),
+        ],
+    )
+    store[KEY_A] = doc
+
+    hits = store.search_corpus("flux capacitor", max_results=10)
+
+    assert len(hits) == 1
+    hit = hits[0]
+    assert hit.document_key == KEY_A
+    assert hit.anchor == doc.texts[0].get_ref().cref
+    assert hit.page == 3
+    assert "flux capacitor" in hit.snippet
+
+
+def test_search_limits_results(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    entries = [(f"widget number {i} in the catalog", i + 1) for i in range(5)]
+    store[KEY_A] = make_corpus_document("doc-a", entries)
+
+    hits = store.search_corpus("widget", max_results=2)
+
+    assert len(hits) == 2
+
+
+def test_search_filters_by_document_keys(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document("doc-a", [("shared banana term", 1)])
+    store[KEY_B] = make_corpus_document("doc-b", [("shared banana term", 2)])
+
+    hits = store.search_corpus("banana", max_results=10, document_keys=[KEY_B])
+
+    assert [hit.document_key for hit in hits] == [KEY_B]
+
+
+def test_search_index_survives_restart(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document("doc-a", [("persistent aardvark facts", 4)])
+
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    hits = reborn.search_corpus("aardvark", max_results=10)
+
+    assert len(hits) == 1
+    assert hits[0].document_key == KEY_A
+    assert hits[0].page == 4
+
+
+def test_search_index_rebuilds_when_missing(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document("doc-a", [("rebuildable zeppelin manual", 2)])
+    (tmp_path / _INDEX_FILENAME).unlink()
+
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    hits = reborn.search_corpus("zeppelin", max_results=10)
+
+    assert len(hits) == 1
+    assert hits[0].document_key == KEY_A
+    assert hits[0].anchor == store[KEY_A].texts[0].get_ref().cref
+
+
+def test_corrupt_index_does_not_break_conversion(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document("doc-a", [("first quokka document", 1)])
+
+    (tmp_path / _INDEX_FILENAME).write_bytes(b"this is not a sqlite database")
+
+    # Storing a new conversion must not raise even though the index is junk.
+    store[KEY_B] = make_corpus_document("doc-b", [("second quokka document", 2)])
+
+    hits = store.search_corpus("quokka", max_results=10)
+    assert {hit.document_key for hit in hits} == {KEY_A, KEY_B}
+
+
+def test_deleted_document_removed_from_search(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document("doc-a", [("shared mongoose topic", 1)])
+    store[KEY_B] = make_corpus_document("doc-b", [("shared mongoose topic", 2)])
+
+    del store[KEY_A]
+    hits = store.search_corpus("mongoose", max_results=10)
+
+    assert [hit.document_key for hit in hits] == [KEY_B]
+
+
+def test_search_drops_entries_for_missing_documents(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document("doc-a", [("externally removed ocelot", 1)])
+
+    # Simulate another process deleting the document but not the index rows.
+    (tmp_path / f"{KEY_A}.json").unlink()
+    (tmp_path / f"{KEY_A}.meta.json").unlink()
+
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    assert reborn.search_corpus("ocelot", max_results=10) == []
+
+
+def test_session_edits_do_not_change_index(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    doc = make_corpus_document("doc-a", [("original narwhal wording", 1)])
+    store[KEY_A] = doc
+
+    # Tool edits mutate session memory only; the index keeps reflecting the
+    # immutable conversion artifact.
+    doc.texts[0].text = "edited kraken wording"
+
+    assert store.search_corpus("kraken", max_results=10) == []
+    assert len(store.search_corpus("narwhal", max_results=10)) == 1
+
+
+def test_authored_documents_are_not_indexed(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document(
+        "draft", [("unpublished ibex draft", 1)], converted=False
+    )
+
+    assert store.search_corpus("ibex", max_results=10) == []
+
+
+def test_search_handles_special_query_characters(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document(
+        "doc-a", [("the don't-panic guide to towels", 1)]
+    )
+
+    for query in ["don't", 'panic - "guide"', "AND OR NOT", "(towels", "*"]:
+        hits = store.search_corpus(query, max_results=10)
+        assert isinstance(hits, list)
+
+    assert len(store.search_corpus("don't-panic", max_results=10)) == 1
+
+
+def test_table_content_is_searchable(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    doc = make_corpus_document("doc-a", [("intro paragraph", 1)])
+    cells = [
+        TableCell(
+            text=text,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=col,
+            end_col_offset_idx=col + 1,
+        )
+        for col, text in enumerate(["Voltage", "1.21 gigawatts"])
+    ]
+    doc.add_table(
+        data=TableData(num_rows=1, num_cols=2, table_cells=cells),
+        prov=_prov(7, 0),
+    )
+    store[KEY_A] = doc
+
+    hits = store.search_corpus("voltage", max_results=10)
+
+    assert len(hits) == 1
+    assert hits[0].anchor == doc.tables[0].get_ref().cref
+    assert hits[0].page == 7
+
+
+def test_in_memory_store_search_corpus() -> None:
+    store = InMemoryDocumentStore()
+    store[KEY_A] = make_corpus_document("doc-a", [("volatile wombat notes", 6)])
+
+    hits = store.search_corpus("wombat", max_results=10)
+    assert len(hits) == 1
+    assert hits[0].page == 6
+
+    del store[KEY_A]
+    assert store.search_corpus("wombat", max_results=10) == []
+
+
+def test_search_without_fts5_raises_clear_error(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document("doc-a", [("any content", 1)])
+
+    store._index._fts5_available = False
+
+    with pytest.raises(RuntimeError, match="FTS5"):
+        store.search_corpus("content", max_results=10)
+
+
+def test_search_across_documents_tool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import docling_mcp.tools.corpus as corpus
+
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_corpus_document(
+        "doc-a", [("the tardigrade survives in vacuum", 9)]
+    )
+    monkeypatch.setattr(corpus, "local_document_cache", store)
+
+    hits = corpus.search_across_documents(query="tardigrade", max_results=5)
+
+    assert len(hits) == 1
+    assert hits[0].document_key == KEY_A
+    assert hits[0].anchor == store[KEY_A].texts[0].get_ref().cref
+    assert hits[0].page == 9
+    assert "tardigrade" in hits[0].snippet
+
+
+def test_search_across_documents_tool_rejects_empty_query(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import docling_mcp.tools.corpus as corpus
+
+    monkeypatch.setattr(
+        corpus, "local_document_cache", LocalDocumentStore(cache_dir=tmp_path)
+    )
+
+    with pytest.raises(ValueError, match="query"):
+        corpus.search_across_documents(query="   ", max_results=5)
+
+
+def test_search_across_documents_tool_rejects_malformed_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import docling_mcp.tools.corpus as corpus
+
+    monkeypatch.setattr(
+        corpus, "local_document_cache", LocalDocumentStore(cache_dir=tmp_path)
+    )
+
+    with pytest.raises(ValueError, match="document key"):
+        corpus.search_across_documents(
+            query="anything", max_results=5, document_keys=["../../escape"]
+        )

--- a/tests/test_document_manipulation.py
+++ b/tests/test_document_manipulation.py
@@ -31,12 +31,12 @@ def test_search_for_text_in_document_anchors() -> None:
     # Load two documents into the local cache to search across
     file_path = Path("./tests/data/amt_handbook_sample.json")
     doc = DoclingDocument.load_from_json(filename=file_path)
-    doc_1_key = "test_doc_1"
+    doc_1_key = "1" * 32
     local_document_cache[doc_1_key] = doc
 
     file_path = Path("./tests/data/lorem_ipsum.docx.json")
     doc = DoclingDocument.load_from_json(filename=file_path)
-    doc_2_key = "test_doc_2"
+    doc_2_key = "2" * 32
     local_document_cache[doc_2_key] = doc
 
     # Test exact match searches

--- a/tests/test_document_store.py
+++ b/tests/test_document_store.py
@@ -1,0 +1,482 @@
+"""Test the persistent document store and corpus tools."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from docling_core.types.doc.common.origin import DocumentOrigin
+from docling_core.types.doc.document import DoclingDocument
+from docling_core.types.doc.labels import DocItemLabel
+
+from docling_mcp.docling_cache import get_cache_key
+from docling_mcp.store.local import InMemoryDocumentStore, LocalDocumentStore
+
+not_root = pytest.mark.skipif(
+    getattr(os, "geteuid", lambda: 1)() == 0,
+    reason="permission bits do not bind root",
+)
+
+
+def make_document(name: str, text: str, converted: bool = True) -> DoclingDocument:
+    doc = DoclingDocument(name=name)
+    if converted:
+        doc.origin = DocumentOrigin(
+            mimetype="application/pdf",
+            binary_hash=hash(name) & 0xFFFFFFFF,
+            filename=f"{name}.pdf",
+        )
+    doc.add_text(label=DocItemLabel.TEXT, text=text)
+    return doc
+
+
+KEY_A = "a" * 32
+KEY_B = "b" * 32
+KEY_C = "c" * 32
+
+
+def test_roundtrip_and_mapping_semantics(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+
+    assert KEY_A not in store
+    store[KEY_A] = make_document("doc-a", "hello world")
+
+    assert KEY_A in store
+    assert store[KEY_A].name == "doc-a"
+    assert set(store.keys()) == {KEY_A}
+    assert len(store) == 1
+
+
+def test_restart_survival(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    doc = make_document("doc-a", "survives restarts")
+    store[KEY_A] = doc
+
+    # A new instance over the same directory simulates a server restart.
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+
+    assert KEY_A in reborn
+    loaded = reborn[KEY_A]
+    assert loaded.name == "doc-a"
+    assert loaded.export_to_markdown() == doc.export_to_markdown()
+
+
+def test_authored_documents_stay_memory_only(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("draft", "work in progress", converted=False)
+
+    assert KEY_A in store
+
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    assert KEY_A not in reborn
+
+
+def test_edits_are_session_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import docling_mcp.tools.manipulation as manipulation
+
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    doc = make_document("doc-a", "original text")
+    store[KEY_A] = doc
+    anchor = doc.texts[0].get_ref().cref
+    monkeypatch.setattr(manipulation, "local_document_cache", store)
+
+    manipulation.update_text_of_document_item_at_anchor(
+        document_key=KEY_A, document_anchor=anchor, updated_text="edited text"
+    )
+
+    # The edit is visible in this session but the persisted conversion
+    # artifact stays pristine: a restart serves the converted source.
+    assert "edited text" in store[KEY_A].export_to_markdown()
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    assert "original text" in reborn[KEY_A].export_to_markdown()
+
+
+def test_persist_failure_keeps_memory_authoritative(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+
+    def boom(self: DoclingDocument, filename: Path) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(DoclingDocument, "save_as_json", boom)
+    store[KEY_A] = make_document("doc-a", "unpersisted")
+
+    assert "unpersisted" in store[KEY_A].export_to_markdown()
+    assert not (tmp_path / f"{KEY_A}.json").exists()
+
+
+def test_originless_overwrite_removes_disk_copy(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "converted")
+    store[KEY_A] = make_document("draft", "replaced in memory", converted=False)
+
+    assert "replaced in memory" in store[KEY_A].export_to_markdown()
+
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    assert KEY_A not in reborn
+
+
+def test_delete_removes_memory_and_disk(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "to delete")
+
+    del store[KEY_A]
+
+    assert KEY_A not in store
+    assert not list(tmp_path.glob("*.json"))
+    with pytest.raises(KeyError):
+        del store[KEY_A]
+
+
+@not_root
+def test_failed_disk_removal_raises_on_delete(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "undeletable")
+
+    tmp_path.chmod(0o500)
+    try:
+        with pytest.raises(OSError):
+            del store[KEY_A]
+    finally:
+        tmp_path.chmod(0o700)
+
+    # Deletion did not silently half-succeed: the document is still there.
+    assert KEY_A in store
+    assert "undeletable" in store[KEY_A].export_to_markdown()
+
+
+def test_corrupt_document_file_behaves_like_absent_key(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    (tmp_path / f"{KEY_A}.json").write_text("{not a document", encoding="utf-8")
+    assert KEY_A in store
+
+    with pytest.raises(KeyError):
+        store[KEY_A]
+
+    # The corrupt entry is quarantined, so membership no longer reports it
+    # and the source can be converted again.
+    assert KEY_A not in store
+    assert not (tmp_path / f"{KEY_A}.json").exists()
+
+
+def test_invalid_keys_are_rejected(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    evil = "../../escape"
+
+    with pytest.raises(ValueError):
+        store[evil] = make_document("doc", "text")
+    assert evil not in store
+    with pytest.raises(KeyError):
+        store[evil]
+    with pytest.raises(KeyError):
+        del store[evil]
+    assert not (tmp_path.parent / "escape.json").exists()
+
+
+def test_keys_with_trailing_newline_are_rejected(tmp_path: Path) -> None:
+    from docling_mcp.store.local import is_valid_document_key
+
+    sneaky = "a" * 32 + "\n"
+    assert not is_valid_document_key(sneaky)
+
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    with pytest.raises(ValueError):
+        store[sneaky] = make_document("doc", "text")
+
+
+def test_bulk_mutation_apis_validate_keys(tmp_path: Path) -> None:
+    doc = make_document("doc", "text")
+
+    memory_store = InMemoryDocumentStore()
+    with pytest.raises(ValueError):
+        memory_store.update({"../../escape": doc})
+    with pytest.raises(ValueError):
+        memory_store.setdefault("../../escape", doc)
+
+    local_store = LocalDocumentStore(cache_dir=tmp_path)
+    with pytest.raises(ValueError):
+        local_store.update({"../../escape": doc})
+    with pytest.raises(ValueError):
+        local_store.setdefault("../../escape", doc)
+
+
+def test_disk_scan_ignores_malformed_filenames(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "real")
+    (tmp_path / (KEY_B + "\n.json")).write_text("{}", encoding="utf-8")
+
+    assert set(store.keys()) == {KEY_A}
+    assert len(store) == 1
+
+
+@not_root
+def test_unwritable_directory_raises_at_construction(tmp_path: Path) -> None:
+    # An owner-restricted directory is auto-tightened to 0700, so true
+    # unwritability is modeled by a locked parent the store cannot create
+    # its directory under.
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)
+    try:
+        with pytest.raises(OSError):
+            LocalDocumentStore(cache_dir=locked / "cache")
+    finally:
+        locked.chmod(0o700)
+
+
+@not_root
+def test_factory_falls_back_to_memory_when_unwritable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from docling_mcp.settings.store import settings as store_settings
+    from docling_mcp.store.factory import create_document_store
+
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o500)
+    monkeypatch.setattr(store_settings, "cache_persist", True)
+    monkeypatch.setattr(store_settings, "cache_dir", locked / "cache")
+    try:
+        store = create_document_store()
+    finally:
+        locked.chmod(0o700)
+
+    assert isinstance(store, InMemoryDocumentStore)
+
+
+@not_root
+def test_store_files_are_owner_only(tmp_path: Path) -> None:
+    base = tmp_path / "cache"
+    store = LocalDocumentStore(cache_dir=base)
+    store[KEY_A] = make_document("doc-a", "private")
+
+    assert (base.stat().st_mode & 0o777) == 0o700
+    assert ((base / f"{KEY_A}.json").stat().st_mode & 0o777) == 0o600
+    assert ((base / f"{KEY_A}.meta.json").stat().st_mode & 0o777) == 0o600
+
+
+@not_root
+def test_pre_existing_directory_is_tightened(tmp_path: Path) -> None:
+    base = tmp_path / "cache"
+    base.mkdir(mode=0o755)
+
+    LocalDocumentStore(cache_dir=base)
+
+    assert (base.stat().st_mode & 0o777) == 0o700
+
+
+def test_list_metadata(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "converted")
+    store[KEY_B] = make_document("draft", "authored", converted=False)
+
+    records = {r.document_key: r for r in store.list_metadata()}
+
+    assert set(records) == {KEY_A, KEY_B}
+    assert records[KEY_A].source_filename == "doc-a.pdf"
+    assert records[KEY_A].stored_at is not None
+    assert records[KEY_B].stored_at is None
+
+
+def test_list_metadata_prefers_live_memory_state(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    doc = make_document("doc-a", "converted")
+    store[KEY_A] = doc
+
+    # Mutate the live object; descriptive fields must reflect memory while
+    # the persisted timestamp is retained from the sidecar.
+    doc.name = "renamed"
+    records = {r.document_key: r for r in store.list_metadata()}
+
+    assert records[KEY_A].name == "renamed"
+    assert records[KEY_A].stored_at is not None
+
+
+def test_list_metadata_rejects_mismatched_sidecar(tmp_path: Path) -> None:
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "converted")
+
+    meta_path = tmp_path / f"{KEY_A}.meta.json"
+    record = json.loads(meta_path.read_text(encoding="utf-8"))
+    record["document_key"] = KEY_B
+    meta_path.write_text(json.dumps(record), encoding="utf-8")
+
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    records = {r.document_key: r for r in reborn.list_metadata()}
+
+    # The mismatched sidecar must not advertise KEY_B; the document file
+    # still proves KEY_A exists.
+    assert KEY_B not in records
+    assert KEY_A in records
+    assert records[KEY_A].stored_at is not None
+
+
+def test_in_memory_store_list_metadata() -> None:
+    store = InMemoryDocumentStore()
+    store[KEY_A] = make_document("doc-a", "in memory")
+
+    records = store.list_metadata()
+
+    assert len(records) == 1
+    assert records[0].document_key == KEY_A
+    assert records[0].stored_at is None
+
+
+def test_in_memory_store_rejects_invalid_keys() -> None:
+    store = InMemoryDocumentStore()
+    with pytest.raises(ValueError):
+        store["../../escape"] = make_document("doc", "text")
+
+
+def test_cache_key_dedupes_identical_content(tmp_path: Path) -> None:
+    file_one = tmp_path / "one.pdf"
+    file_two = tmp_path / "sub" / "two.pdf"
+    file_two.parent.mkdir()
+    file_one.write_bytes(b"same bytes")
+    file_two.write_bytes(b"same bytes")
+
+    assert get_cache_key(str(file_one)) == get_cache_key(str(file_two))
+
+
+def test_cache_key_distinguishes_file_formats(tmp_path: Path) -> None:
+    file_one = tmp_path / "doc.html"
+    file_two = tmp_path / "doc.md"
+    file_one.write_bytes(b"same bytes")
+    file_two.write_bytes(b"same bytes")
+
+    # The suffix selects the input format, so identical bytes under
+    # different extensions must convert separately.
+    assert get_cache_key(str(file_one)) != get_cache_key(str(file_two))
+
+
+def test_cache_key_changes_when_content_changes(tmp_path: Path) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"version one")
+    key_one = get_cache_key(str(source))
+
+    source.write_bytes(b"version two, longer")
+    key_two = get_cache_key(str(source))
+
+    assert key_one != key_two
+
+
+def test_cache_key_detects_same_size_rewrite_with_preserved_mtime(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"aaaa")
+    key_one = get_cache_key(str(source))
+    stat = source.stat()
+
+    source.write_bytes(b"bbbb")
+    os.utime(source, (stat.st_atime, stat.st_mtime))
+
+    assert get_cache_key(str(source)) != key_one
+
+
+def test_cache_key_for_urls_uses_source_string() -> None:
+    url = "https://example.com/spec.pdf"
+
+    assert get_cache_key(url) == get_cache_key(url)
+    assert get_cache_key(url) != get_cache_key(url + "?v=2")
+
+
+def test_cache_key_uses_converter_supplied_context(tmp_path: Path) -> None:
+    from docling_mcp.docling_cache import (
+        local_conversion_context,
+        remote_conversion_context,
+    )
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+
+    local_key = get_cache_key(str(source), conversion=local_conversion_context())
+    remote_key = get_cache_key(str(source), conversion=remote_conversion_context())
+
+    # A fallback conversion executed locally must never share a key with a
+    # remote conversion of the same source.
+    assert local_key != remote_key
+
+
+def test_cache_key_covers_conversion_configuration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from docling_mcp.settings.service_client import (
+        ConversionMode,
+        settings as service_settings,
+    )
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+
+    monkeypatch.setattr(service_settings, "conversion_mode", ConversionMode.LOCAL)
+    local_key = get_cache_key(str(source))
+
+    monkeypatch.setattr(service_settings, "conversion_mode", ConversionMode.REMOTE)
+    monkeypatch.setattr(service_settings, "service_url", "https://serve-a.example.com")
+    remote_key_a = get_cache_key(str(source))
+
+    monkeypatch.setattr(service_settings, "service_url", "https://serve-b.example.com")
+    remote_key_b = get_cache_key(str(source))
+
+    assert local_key != remote_key_a
+    assert remote_key_a != remote_key_b
+
+
+def test_list_converted_documents_tool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import docling_mcp.tools.corpus as corpus
+
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "listed")
+    store[KEY_B] = make_document("draft", "not listed", converted=False)
+    monkeypatch.setattr(corpus, "local_document_cache", store)
+
+    entries = corpus.list_converted_documents()
+
+    assert len(entries) == 1
+    assert entries[0].document_key == KEY_A
+    assert entries[0].source_filename == "doc-a.pdf"
+
+
+def test_list_converted_documents_survives_corrupt_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import docling_mcp.tools.corpus as corpus
+
+    store = LocalDocumentStore(cache_dir=tmp_path)
+    store[KEY_A] = make_document("doc-a", "listed")
+    (tmp_path / f"{KEY_A}.meta.json").write_text("{not json", encoding="utf-8")
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    monkeypatch.setattr(corpus, "local_document_cache", reborn)
+
+    entries = corpus.list_converted_documents()
+
+    assert len(entries) == 1
+    assert entries[0].document_key == KEY_A
+    assert entries[0].stored_at is not None
+
+
+def test_restored_document_gives_clean_error_in_generation_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from collections import defaultdict
+
+    import docling_mcp.tools.generation as generation
+
+    seed = LocalDocumentStore(cache_dir=tmp_path)
+    seed[KEY_A] = make_document("doc-a", "restored")
+
+    reborn = LocalDocumentStore(cache_dir=tmp_path)
+    monkeypatch.setattr(generation, "local_document_cache", reborn)
+    monkeypatch.setattr(generation, "local_stack_cache", defaultdict(list))
+
+    with pytest.raises(ValueError, match="Stack size is zero"):
+        generation.add_paragraph_to_docling_document(
+            document_key=KEY_A, paragraph="new paragraph"
+        )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -35,6 +35,7 @@ async def test_list_tools(mcp_client: AsyncGenerator[Any, Any]) -> None:
         "update_text_of_document_item_at_anchor",
         "delete_document_items_at_anchors",
         "list_converted_documents",
+        "search_across_documents",
     ]
 
     assert tools == gold_tools

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -34,6 +34,7 @@ async def test_list_tools(mcp_client: AsyncGenerator[Any, Any]) -> None:
         "get_text_of_document_item_at_anchor",
         "update_text_of_document_item_at_anchor",
         "delete_document_items_at_anchors",
+        "list_converted_documents",
     ]
 
     assert tools == gold_tools

--- a/tests/test_remote_sources.py
+++ b/tests/test_remote_sources.py
@@ -1,0 +1,118 @@
+"""Test fetch-to-temp resolution of object-storage source URIs."""
+
+import importlib.util
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from docling_core.types.doc.document import DoclingDocument
+
+from docling_mcp.tools.converters.sources import fetched_source
+
+fsspec = pytest.importorskip("fsspec")
+
+OBJECT_URI = "memory://bucket/spec.pdf"
+
+
+def _register_memory_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route the fsspec in-memory filesystem through the shim for tests."""
+    import docling_mcp.tools.converters.sources as sources
+
+    monkeypatch.setitem(sources._FSSPEC_SCHEMES, "memory", ("fsspec", "s3"))
+
+
+def test_local_paths_pass_through(tmp_path: Path) -> None:
+    source = str(tmp_path / "doc.pdf")
+    with fetched_source(source) as resolved:
+        assert resolved == source
+
+
+def test_http_urls_pass_through() -> None:
+    url = "https://example.com/spec.pdf"
+    with fetched_source(url) as resolved:
+        assert resolved == url
+
+
+def test_object_uri_fetched_to_temp_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    _register_memory_scheme(monkeypatch)
+    fsspec.filesystem("memory").pipe("/bucket/spec.pdf", b"fake pdf bytes")
+
+    with fetched_source(OBJECT_URI) as resolved:
+        path = Path(resolved)
+        assert resolved != OBJECT_URI
+        # The suffix selects the input format, so it must survive the fetch.
+        assert path.suffix == ".pdf"
+        assert path.read_bytes() == b"fake pdf bytes"
+
+    assert not path.exists()
+
+
+def test_fetch_failure_removes_temp_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    _register_memory_scheme(monkeypatch)
+
+    with pytest.raises(FileNotFoundError):
+        with fetched_source("memory://bucket/absent.pdf"):
+            pass
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("s3fs") is not None,
+    reason="s3fs is installed; the missing-provider error cannot occur",
+)
+def test_missing_provider_package_raises_install_hint() -> None:
+    with pytest.raises(ValueError, match=r"docling-mcp\[s3\]"):
+        with fetched_source("s3://bucket/key.pdf"):
+            pass
+
+
+@patch("docling_mcp.tools.converters.remote.DoclingServiceClient")
+@patch("docling_mcp.tools.converters.remote.settings")
+def test_remote_converter_fetches_object_uri(
+    mock_settings: Any, mock_client_class: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The remote converter converts a fetched local copy of an object URI."""
+    import docling_mcp.tools.converters.remote as remote_mod
+    from docling_mcp.tools.converters.remote import RemoteDocumentConverter
+
+    mock_settings.service_url = "https://serve.example.com"
+    mock_settings.service_api_key = None
+    cache: dict[str, DoclingDocument] = {}
+    monkeypatch.setattr(remote_mod, "local_document_cache", cache)
+    monkeypatch.setattr(remote_mod, "local_stack_cache", defaultdict(list))
+
+    _register_memory_scheme(monkeypatch)
+    fsspec.filesystem("memory").pipe("/bucket/spec.pdf", b"object bytes")
+
+    fetched: dict[str, Any] = {}
+
+    def fake_convert(source: str, options: Any) -> Any:
+        fetched["source"] = source
+        fetched["existed"] = Path(source).exists()
+        result = Mock()
+        result.status.is_error = False
+        result.document = DoclingDocument(name="spec")
+        return result
+
+    mock_client_class.return_value.convert.side_effect = fake_convert
+
+    converter = RemoteDocumentConverter()
+    output = converter.convert_document(OBJECT_URI)
+
+    # The service client received a local temp copy, not the object URI.
+    assert output.from_cache is False
+    assert fetched["existed"] is True
+    assert fetched["source"] != OBJECT_URI
+    assert fetched["source"].endswith(".pdf")
+
+    # The converted document records the original URI as its source.
+    ((key, doc),) = cache.items()
+    assert key == output.document_key
+    assert any(t.text == f"source: {OBJECT_URI}" for t in doc.texts)
+
+    # A second conversion of the same bytes dedupes on content.
+    again = converter.convert_document(OBJECT_URI)
+    assert again.from_cache is True
+    assert again.document_key == output.document_key

--- a/uv.lock
+++ b/uv.lock
@@ -1,16 +1,19 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
@@ -47,6 +50,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8d/75/94cd5d389649578aca399e5aa822637eec18319a1dadc400ffe2f9a7493f/accelerate-1.14.0.tar.gz", hash = "sha256:41b9c4377a54e0b460a959b0defa1b736e4ca0a2373252d9a539964c2afe3c8d", size = 412167, upload-time = "2026-06-11T13:45:52.326Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl", hash = "sha256:e94390c2863b873be18f623f9df48a0d8fe5eff13ea7f1a00092b0a7904888c6", size = 389246, upload-time = "2026-06-11T13:45:50.477Z" },
+]
+
+[[package]]
+name = "adlfs"
+version = "2026.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "azure-identity" },
+    { name = "azure-storage-blob", extra = ["aio"] },
+    { name = "fsspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/12/4cff4d6734ba073acd86adf789171946be81724ca143c21ab41144633573/adlfs-2026.5.0.tar.gz", hash = "sha256:abb24e3afba57c6766799514b6f12b65b577d4946254961c15cef71e5b51f374", size = 53879, upload-time = "2026-05-05T20:20:08.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/5a/225a82252fdbddd21e25552208c2a2cd69afd19e06de79d28841c252537d/adlfs-2026.5.0-py3-none-any.whl", hash = "sha256:7acf1d62eade0c1c0b1b0762b36cb0921a646dd41311af1d261f52fb24fe4e57", size = 44910, upload-time = "2026-05-05T20:20:07.358Z" },
+]
+
+[[package]]
+name = "aiobotocore"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aioitertools" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "multidict" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/a7/bc31b7046c610471f0630819ca5d2a57ac4efa8d47135cb53e43f2785390/aiobotocore-3.8.0.tar.gz", hash = "sha256:80a1eb64ea915f3af3c1518669975bae74a17b2f37c14eb0fa2f83b915974670", size = 131368, upload-time = "2026-07-17T03:10:30.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl", hash = "sha256:8bc605132cadfe844a3f334635a0a64fa5e360a4a206e915d99d53db5b6deeba", size = 91169, upload-time = "2026-07-17T03:10:28.771Z" },
 ]
 
 [[package]]
@@ -193,6 +230,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/19/08d41839658bdd44a0ed2480f3891705ecb487ce28c0dde62c9040c997e0/aiohttp-3.14.3-cp314-cp314t-win32.whl", hash = "sha256:b304db572b4368edd8dda8a2274f73156fe15558fca4a917cb8a09fc47af5963", size = 474180, upload-time = "2026-07-23T01:57:19.306Z" },
     { url = "https://files.pythonhosted.org/packages/99/5d/3cd6ef0a2b2851f7ab913b5b079334781bd50ff56a323e4454063377a080/aiohttp-3.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b20032766aedf6261c7a566585a40867d092ac03a0d81592d5370ef9b054f99b", size = 500528, upload-time = "2026-07-23T01:57:21.762Z" },
     { url = "https://files.pythonhosted.org/packages/a4/37/cfd1ed540a4d318da025590d96b728e63713c09e9377950fc655dadeb856/aiohttp-3.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2e1161602f45a54de2ce0905243a95f58cb42dcd378402f3697f5e0b21e9d2e7", size = 469280, upload-time = "2026-07-23T01:57:24.241Z" },
+]
+
+[[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
 ]
 
 [[package]]
@@ -355,6 +401,60 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[package.optional-dependencies]
+aio = [
+    { name = "aiohttp" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
+]
+
+[package.optional-dependencies]
+aio = [
+    { name = "azure-core", extra = ["aio"] },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -400,6 +500,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/f1/1917891851ac5ac09bb9f4862b8fc9252a009d7c24e8688bb67e4383d9e7/botocore-1.43.46.tar.gz", hash = "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533", size = 15694635, upload-time = "2026-07-10T19:32:00.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/f2/4bd8f2f419088feb3ce55f0ca91040ff902f402edfd197450b20a2e1d533/botocore-1.43.46-py3-none-any.whl", hash = "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60", size = 15380350, upload-time = "2026-07-10T19:31:57.616Z" },
 ]
 
 [[package]]
@@ -649,13 +763,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -875,7 +992,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.12' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.12' and sys_platform == 'win32') or (python_full_version < '3.15' and sys_platform != 'darwin' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -1174,6 +1291,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+azure = [
+    { name = "adlfs" },
+]
+gcs = [
+    { name = "gcsfs" },
+]
 llama-index-rag = [
     { name = "llama-index" },
     { name = "llama-index-core" },
@@ -1194,6 +1317,9 @@ local = [
 mellea = [
     { name = "mellea", version = "0.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "mellea", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+s3 = [
+    { name = "s3fs" },
 ]
 smolagents = [
     { name = "accelerate" },
@@ -1227,9 +1353,11 @@ examples = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'smolagents'", specifier = ">=0.20.0" },
+    { name = "adlfs", marker = "extra == 'azure'", specifier = ">=2024.7.0" },
     { name = "docling-core", specifier = ">=2.51.0" },
     { name = "docling-slim", extras = ["service-client"], specifier = "~=2.92" },
     { name = "docling-slim", extras = ["standard"], marker = "extra == 'local'", specifier = "~=2.92" },
+    { name = "gcsfs", marker = "extra == 'gcs'", specifier = ">=2024.9.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "llama-index", marker = "extra == 'llama-index-rag'", specifier = ">=0.12.33" },
     { name = "llama-index-core", marker = "extra == 'llama-index-rag'", specifier = ">=0.12.28" },
@@ -1247,12 +1375,13 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.10" },
     { name = "pydantic-settings", specifier = "~=2.4" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "s3fs", marker = "extra == 's3'", specifier = ">=2024.9.0" },
     { name = "smolagents", extras = ["mcp", "litellm"], marker = "extra == 'smolagents'", specifier = ">=1.0.0" },
     { name = "torch", marker = "extra == 'smolagents'", specifier = ">=2.0.0" },
     { name = "transformers", marker = "sys_platform == 'darwin' and extra == 'smolagents'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,<5.9.0" },
     { name = "transformers", marker = "sys_platform != 'darwin' and extra == 'smolagents'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,<6.0.0" },
 ]
-provides-extras = ["local", "llama-index-rag", "llama-stack", "smolagents", "mellea"]
+provides-extras = ["local", "llama-index-rag", "llama-stack", "smolagents", "mellea", "s3", "gcs", "azure"]
 
 [package.metadata.requires-dev]
 constraints = [{ name = "numpy", specifier = "<2.5.0" }]
@@ -1629,6 +1758,25 @@ wheels = [
 ]
 
 [[package]]
+name = "gcsfs"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "decorator" },
+    { name = "fsspec" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-storage" },
+    { name = "google-cloud-storage-control" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/33/58e23c6f492e091c2f01ae1bffe331aa97e18a0b3d24ff90ef648335ddc8/gcsfs-2026.7.0.tar.gz", hash = "sha256:2df36ce1e9010e76dc4295774030495a97496838483c619e9f63bc0ab7bdc770", size = 1265874, upload-time = "2026-07-06T15:02:30.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/eb/a5c4b39903928e6be7735cc7aa31b6c3bbf3d887419e1e7ac751dba02233/gcsfs-2026.7.0-py3-none-any.whl", hash = "sha256:8ce6c08ea64302d8fd4bc23a615ccd9e7752541cde1a88ec8362109bd79cde78", size = 91131, upload-time = "2026-07-06T15:02:29.208Z" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1650,6 +1798,165 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/62/8fb1fb647d2788c950d69d6a769cd9d55c918ac1fc57be2f90b7e4029787/google_api_core-2.33.0.tar.gz", hash = "sha256:3a36bcc3e319783f4c97da41f6f45ea6ffcaa55848e341de16e09cb70243c2bb", size = 181607, upload-time = "2026-07-22T16:28:28.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/31/5056a347bb934ea04583c8b27916ef1501729c72638629545bce26ff4223/google_api_core-2.33.0-py3-none-any.whl", hash = "sha256:a2e22a0c1d0f03eafff1858b38cf46f832d5902b0c052235bf0ab8402929fbdc", size = 176462, upload-time = "2026-07-22T16:28:22.447Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/dbc946a407401b975f0719658f18e664ece2109f79ffd1ff3bf226c205f4/google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051", size = 365820, upload-time = "2026-07-21T21:53:28.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/63/50636aae68c9bf17c891c7eb18b49baa9bd6b31d2a97b8de4813a9fc8d1c/google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6", size = 258588, upload-time = "2026-07-21T21:53:26.399Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/25/355ed97c1723c787dfaa888808d55db18371f82c38ff862357b1e902cd19/google_cloud_storage-3.13.0.tar.gz", hash = "sha256:d11d8706ea1520fba0f21043bcb7897caf7015d76ce1ad9a4f60237e4d7a9f6c", size = 17340960, upload-time = "2026-07-13T19:10:07.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e8/b3678a0931ee7d4b3fdaf0813e6206d66e0922b2c26d912f308728b5b95a/google_cloud_storage-3.13.0-py3-none-any.whl", hash = "sha256:648af3ef8a6acc674e1359d3c920c67eb89a7a5ab66b336bd3ac43fed6b5ab84", size = 341428, upload-time = "2026-07-13T19:09:52.39Z" },
+]
+
+[[package]]
+name = "google-cloud-storage-control"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/ae/707995271f77e3c1da715c740160f98f87a79a5c601b28d17c4d2500c037/google_cloud_storage_control-1.12.0.tar.gz", hash = "sha256:49090d03532c0c84c6246a5fd490c31fd4bbffb4c7771c0a6744ec23a194a5f6", size = 137036, upload-time = "2026-06-03T16:14:00.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/ba/f187f30fb2c8bb5dbb0de0fcb0dec2f8fab0b782ab42facc83ea02628f1b/google_cloud_storage_control-1.12.0-py3-none-any.whl", hash = "sha256:20f7f1252fa5635d47e12f746aa69d719e31eb9405cbbd14cdfba317db27d421", size = 102205, upload-time = "2026-06-03T16:12:43.266Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/ac/6f7bc93886a823ab545948c2dd48143027b2355ad1944c7cf852b338dc91/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff", size = 31296, upload-time = "2025-12-16T00:19:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/97/a5accde175dee985311d949cfcb1249dcbb290f5ec83c994ea733311948f/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:119fcd90c57c89f30040b47c211acee231b25a45d225e3225294386f5d258288", size = 30870, upload-time = "2025-12-16T00:29:17.669Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/63/bec827e70b7a0d4094e7476f863c0dbd6b5f0f1f91d9c9b32b76dcdfeb4e/google_crc32c-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f35aaffc8ccd81ba3162443fabb920e65b1f20ab1952a31b13173a67811467d", size = 33214, upload-time = "2025-12-16T00:40:19.618Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/11b70614df04c289128d782efc084b9035ef8466b3d0a8757c1b6f5cf7ac/google_crc32c-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:864abafe7d6e2c4c66395c1eb0fe12dc891879769b52a3d56499612ca93b6092", size = 33589, upload-time = "2025-12-16T00:40:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/00/a08a4bc24f1261cc5b0f47312d8aebfbe4b53c2e6307f1b595605eed246b/google_crc32c-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:db3fe8eaf0612fc8b20fa21a5f25bd785bc3cd5be69f8f3412b0ac2ffd49e733", size = 34437, upload-time = "2025-12-16T00:35:19.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
 ]
 
 [[package]]
@@ -1787,6 +2094,20 @@ wheels = [
 ]
 
 [[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964", size = 32675, upload-time = "2026-04-01T01:57:47.69Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.82.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1845,6 +2166,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/27/7ccf2ef00f27a8e47a79d641c8ceaf7d3028c7a03d9a97b4c8a9a783c086/grpcio-1.82.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d7ede11d747b4e1bd05e3bc0260e155b65a88735a895a10f6521f19b889511e", size = 7912572, upload-time = "2026-07-08T12:36:08.393Z" },
     { url = "https://files.pythonhosted.org/packages/0d/be/33742482d2753f2d3a1b7641664b6622262d44f2f3b609f13425dd86d36f/grpcio-1.82.1-cp314-cp314-win32.whl", hash = "sha256:3d21f19838dc255ecbb79321b15ae9b98fbddff4c3d4aedb0a81bdd7f4ab572a", size = 4321856, upload-time = "2026-07-08T12:36:10.899Z" },
     { url = "https://files.pythonhosted.org/packages/cc/67/03329c847172c78ddeb1eb9be6b444fdbc12775a84c958b27e427e7b926d/grpcio-1.82.1-cp314-cp314-win_amd64.whl", hash = "sha256:e20f1edbb15f99e3128ec86433f9785fd5a451d8f115e74fe0056134f092a9d5", size = 5141114, upload-time = "2026-07-08T12:36:13.595Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.82.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/4d/3037f220cea14be7e77bb52e7dec18bdc90554e218642c8ebde620de37e3/grpcio_status-1.82.1.tar.gz", hash = "sha256:d9de8ac34763cd468130fdd2923294af7c3d28d09426f6c45221d27c25931130", size = 13906, upload-time = "2026-07-08T12:39:41.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5c/2f6c7e24b99dbaf5f8d7e5b1413fc9fc23360cdeb7f290b49a1c87b49560/grpcio_status-1.82.1-py3-none-any.whl", hash = "sha256:71c7f2bea725c0027fa396b77a55d4e9d90591bab90de4c1c03d4df9a56552f0", size = 14636, upload-time = "2026-07-08T12:39:23.113Z" },
 ]
 
 [[package]]
@@ -1948,13 +2283,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -2080,13 +2418,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -2136,6 +2477,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -2304,6 +2654,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -3133,13 +3492,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "jsonref", marker = "python_full_version >= '3.12'" },
@@ -3203,13 +3565,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -3293,6 +3658,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
 ]
 
 [[package]]
@@ -3588,13 +3979,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -3736,13 +4130,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -3971,6 +4368,15 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -4536,6 +4942,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/3e/29e0d6a2c5adde6ab5772253fd16ab346324026b89a66e354689c86d0584/proto_plus-1.28.2.tar.gz", hash = "sha256:26d843eb99c1e32fdf1d20ff0faae56607f7748fe774acf9ecd5cfe6c6472501", size = 58063, upload-time = "2026-07-22T16:28:29.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/84/4e9a53a062d4073c74897a6bd20fff74d55307341b3e85c081002462b3ef/proto_plus-1.28.2-py3-none-any.whl", hash = "sha256:b874236fcac2358f601e4330bcb76cb8b89c851303ccf4078408b3d4774d1c52", size = 50693, upload-time = "2026-07-22T16:28:24.059Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4650,6 +5068,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
     { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
     { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -5489,6 +5928,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5668,13 +6120,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -5839,6 +6294,20 @@ wheels = [
 ]
 
 [[package]]
+name = "s3fs"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiobotocore" },
+    { name = "aiohttp" },
+    { name = "fsspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/00/6677343dc919d6c072bb04d80210afdd22c16838a8d16b3315c122dc728f/s3fs-2026.6.0.tar.gz", hash = "sha256:b28de7082d0a4f72392884bdc497e34a4a1582f675d214c7da0acf6e950a0083", size = 87358, upload-time = "2026-06-16T02:05:48.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/0b/f68a968b49876eae0f2a515387093cebb2eb9451380a96741cc20efac0d0/s3fs-2026.6.0-py3-none-any.whl", hash = "sha256:60576e31bb31193c1f643f32b4c6439548720ea6918ac702e21cd757c80b5db8", size = 32573, upload-time = "2026-06-16T02:05:47.608Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5924,13 +6393,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
@@ -6118,13 +6590,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -7035,13 +7510,16 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]


### PR DESCRIPTION
Right now the server keeps converted documents in a plain dict, so every restart
throws away all document keys and any workflow longer than one session re-converts
the same files. There's also no way to see what's already converted (#35 touches
on this) and no way to search across documents short of standing up Milvus or
Elasticsearch (#19 and #14 show the friction on that path).

This makes converted documents survive restarts and adds two tools in a new
`corpus` toolgroup:

- `list_converted_documents` returns each converted document with its key, source
  filename, page count and stored timestamp, including documents from earlier
  server sessions
- `search_across_documents` does BM25-ranked full-text search over all converted
  documents and returns the anchor and page for each hit, so an answer can cite
  its source document and page directly

A few notes on the design:

- Persisted documents are immutable conversion artifacts. Edits made through the
  manipulation tools stay in session memory and `save_docling_document` remains
  the way to keep edited content, so a cache hit always returns what the source
  actually converted to.
- Cache keys are content hashes (plus file suffix and conversion config), so the
  same file reached through two paths converts once, and an edited file
  re-converts instead of serving stale results.
- Search uses SQLite FTS5 from the standard library, no new dependencies. The
  index lives beside the stored documents and rebuilds from them when missing or
  corrupt, so it can always be thrown away.
- The converters now also accept s3://, gs:// and abfs:// source URIs, fetched to
  a temp file before conversion. Provider packages are optional extras (`s3`,
  `gcs`, `azure`) and credentials come only from the standard provider chains,
  never from MCP client config.

No existing tool signatures change. Setting `DOCLING_MCP_CACHE_PERSIST=false`
restores the old in-memory behavior. The branch also adds an integration guide
for IBM Bob under docs/integrations.
