### PR TITLE
fix: include pypdfium2 in base installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "docling-core>=2.51.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.9.4",
+    "pypdfium2>=4.30.0,<6.0.0",
     "pydantic~=2.10",
     "pydantic-settings~=2.4",
     "python-dotenv>=1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1143,6 +1143,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pypdfium2" },
     { name = "python-dotenv" },
 ]
 
@@ -1215,6 +1216,7 @@ requires-dist = [
     { name = "ollama", marker = "extra == 'smolagents'", specifier = ">=0.1.0" },
     { name = "pydantic", specifier = "~=2.10" },
     { name = "pydantic-settings", specifier = "~=2.4" },
+    { name = "pypdfium2", specifier = ">=4.30.0,<6.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "smolagents", extras = ["mcp", "litellm"], marker = "extra == 'smolagents'", specifier = ">=1.0.0" },
     { name = "torch", marker = "extra == 'smolagents'", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- add pypdfium2 to the base runtime dependencies
- update only the corresponding project entries in uv.lock
- keep the existing local extra unchanged

## Validation
- `uv lock --check`
- base-only `uv sync --no-dev --no-default-groups`
- verified imports for `pypdfium2` and `docling_mcp.tools.generation`
- verified installed package metadata includes pypdfium2

Closes #108