### PR TITLE
fix(server): construct FastMCP with the correct bind address at startup

### DIFF
--- a/docling_mcp/servers/mcp_server.py
+++ b/docling_mcp/servers/mcp_server.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import typer
 
 from docling_mcp.logger import setup_logger
-from docling_mcp.shared import mcp
+from docling_mcp.shared import init_mcp
 
 app = typer.Typer()
 
@@ -52,6 +52,13 @@ def main(
     if tools is None:
         tools = [*_DEFAULT_TOOLS]
 
+    # Construct the FastMCP instance with the final host/port values *before*
+    # importing any tool or prompt module.  This ensures the SDK's built-in
+    # DNS-rebinding-protection logic runs against the real bind address:
+    # loopback addresses get protection enabled; 0.0.0.0 and other addresses
+    # get it disabled, which is correct for container / Kubernetes deployments.
+    mcp = init_mcp(host=host, port=port)
+
     if ToolGroups.CONVERSION in tools:
         logger.info("loading conversion tools...")
         import docling_mcp.tools.conversion
@@ -82,10 +89,7 @@ def main(
     import docling_mcp.prompts.generation
     import docling_mcp.prompts.manipulation
 
-    # Initialize and run the server
     logger.info("starting up Docling MCP-server ...")
-    mcp.settings.host = host
-    mcp.settings.port = port
     mcp.run(transport=transport.value)
 
 

--- a/docling_mcp/servers/mcp_server.py
+++ b/docling_mcp/servers/mcp_server.py
@@ -52,11 +52,8 @@ def main(
     if tools is None:
         tools = [*_DEFAULT_TOOLS]
 
-    # Construct the FastMCP instance with the final host/port values *before*
-    # importing any tool or prompt module.  This ensures the SDK's built-in
-    # DNS-rebinding-protection logic runs against the real bind address:
-    # loopback addresses get protection enabled; 0.0.0.0 and other addresses
-    # get it disabled, which is correct for container / Kubernetes deployments.
+    # Construct the FastMCP instance with the final host/port values before
+    # importing any tool or prompt module.
     mcp = init_mcp(host=host, port=port)
 
     if ToolGroups.CONVERSION in tools:

--- a/docling_mcp/shared.py
+++ b/docling_mcp/shared.py
@@ -1,4 +1,17 @@
-"""This module defines shared resources."""
+"""Shared resources for the Docling MCP server.
+
+Attributes:
+    mcp: The FastMCP singleton used by all tool and prompt modules.
+        A default instance is created at import time so that tool modules
+        can import the name unconditionally. In server operation it is
+        replaced by `init_mcp()` before any tool or prompt module is
+        imported, ensuring the MCP SDK's DNS-rebinding-protection logic
+        runs with the correct bind address.
+    local_document_cache: In-memory cache mapping document keys to
+        `DoclingDocument` instances, shared across all tools.
+    local_stack_cache: In-memory cache mapping document keys to lists of
+        `NodeItem` instances, used by Llama Stack tools.
+"""
 
 from __future__ import annotations
 
@@ -7,15 +20,6 @@ from mcp.server.fastmcp import FastMCP
 from docling_core.types.doc.document import DoclingDocument
 from docling_core.types.doc.items.node import NodeItem
 
-# The FastMCP singleton.  In normal server operation it is replaced by
-# `init_mcp()` (called from `docling_mcp.servers.mcp_server.main`) *before*
-# any tool or prompt module is imported, so the SDK's DNS-rebinding-protection
-# logic runs with the correct bind address.
-#
-# The default instance below exists solely to satisfy imports that happen
-# outside of `main()` (e.g. direct unit-test imports of tool modules).  It
-# uses the SDK default host ("127.0.0.1") so DNS-rebinding protection is
-# enabled, which is the safe default.
 mcp: FastMCP = FastMCP("docling")
 
 
@@ -23,12 +27,12 @@ def init_mcp(host: str, port: int) -> FastMCP:
     """Create and register the shared FastMCP instance.
 
     Must be called once, before any tool or prompt module is imported.
-    Passing ``host`` and ``port`` at construction time lets the MCP SDK apply
+    Passing `host` and `port` at construction time lets the MCP SDK apply
     its own DNS-rebinding-protection logic with the correct values:
 
-    - ``localhost`` / ``127.0.0.1`` / ``::1`` → protection enabled,
+    - `localhost` / `127.0.0.1` / `::1` → protection enabled,
       allowlist restricted to loopback addresses.
-    - Any other host (e.g. ``0.0.0.0``) → protection disabled, which is the
+    - Any other host (e.g. `0.0.0.0`) → protection disabled, which is the
       safe default for container / Kubernetes deployments where the network
       perimeter is enforced externally.
 
@@ -38,13 +42,12 @@ def init_mcp(host: str, port: int) -> FastMCP:
 
     Returns:
         The newly created FastMCP instance, also stored as the module-level
-        ``mcp`` name so that tool and prompt decorators resolve correctly.
+        `mcp` name so that tool and prompt decorators resolve correctly.
     """
     global mcp
     mcp = FastMCP("docling", host=host, port=port)
     return mcp
 
 
-# Define your shared cache here if it's used by multiple tools
 local_document_cache: dict[str, DoclingDocument] = {}
 local_stack_cache: dict[str, list[NodeItem]] = {}

--- a/docling_mcp/shared.py
+++ b/docling_mcp/shared.py
@@ -1,12 +1,49 @@
 """This module defines shared resources."""
 
+from __future__ import annotations
+
 from mcp.server.fastmcp import FastMCP
 
 from docling_core.types.doc.document import DoclingDocument
 from docling_core.types.doc.items.node import NodeItem
 
-# Create a single shared FastMCP instance
-mcp = FastMCP("docling")
+# The FastMCP singleton.  In normal server operation it is replaced by
+# `init_mcp()` (called from `docling_mcp.servers.mcp_server.main`) *before*
+# any tool or prompt module is imported, so the SDK's DNS-rebinding-protection
+# logic runs with the correct bind address.
+#
+# The default instance below exists solely to satisfy imports that happen
+# outside of `main()` (e.g. direct unit-test imports of tool modules).  It
+# uses the SDK default host ("127.0.0.1") so DNS-rebinding protection is
+# enabled, which is the safe default.
+mcp: FastMCP = FastMCP("docling")
+
+
+def init_mcp(host: str, port: int) -> FastMCP:
+    """Create and register the shared FastMCP instance.
+
+    Must be called once, before any tool or prompt module is imported.
+    Passing ``host`` and ``port`` at construction time lets the MCP SDK apply
+    its own DNS-rebinding-protection logic with the correct values:
+
+    - ``localhost`` / ``127.0.0.1`` / ``::1`` → protection enabled,
+      allowlist restricted to loopback addresses.
+    - Any other host (e.g. ``0.0.0.0``) → protection disabled, which is the
+      safe default for container / Kubernetes deployments where the network
+      perimeter is enforced externally.
+
+    Args:
+        host: The hostname or IP address the server will bind to.
+        port: The TCP port the server will listen on.
+
+    Returns:
+        The newly created FastMCP instance, also stored as the module-level
+        ``mcp`` name so that tool and prompt decorators resolve correctly.
+    """
+    global mcp
+    mcp = FastMCP("docling", host=host, port=port)
+    return mcp
+
 
 # Define your shared cache here if it's used by multiple tools
 local_document_cache: dict[str, DoclingDocument] = {}


### PR DESCRIPTION
## Problem

When running the server with `--host 0.0.0.0` (e.g. in a Kubernetes deployment), clients
connecting via an IP address received a `421 Misdirected Request` response.

The root cause was a lifecycle ordering problem. The `mcp` singleton in `shared.py` was
constructed at module import time with no `host` argument, so the MCP SDK's `FastMCP.__init__`
applied its auto-configuration logic against the default host (`127.0.0.1`), enabling
DNS-rebinding protection with an allowlist restricted to loopback addresses (`localhost:*`,
`127.0.0.1:*`, `[::1]:*`). Later, `main()` mutated `mcp.settings.host` to the CLI-supplied
value, but `transport_security` had already been set and was never updated. Any request arriving
with a non-loopback `Host` header (e.g. `Host: 172.16.1.187:8000`) was rejected with 421 by the
SDK's `TransportSecurityMiddleware`.

## Fix

Introduce `init_mcp(host, port)` in `shared.py`, which constructs the `FastMCP` instance with
the correct bind address before any tool or prompt module is imported. Calling `FastMCP.__init__`
with the real host means the SDK's own auto-configuration logic runs with the right value:

- `localhost` / `127.0.0.1` / `::1` → DNS-rebinding protection enabled, loopback-only allowlist.
- Any other host (e.g. `0.0.0.0`) → protection disabled, which is the correct default for
  container and Kubernetes deployments where the network perimeter is enforced externally.

`main()` now calls `init_mcp(host=host, port=port)` as its first action, before any tool or
prompt module is imported. The post-hoc `mcp.settings.host = host` / `mcp.settings.port = port`
mutations are removed.

The module-level `mcp = FastMCP("docling")` default is retained so that tool modules can import
the name unconditionally at module level (required for the `@mcp.tool()` decorator pattern). This
means `FastMCP` is constructed twice at server startup: once when `shared.py` is first imported,
and once inside `init_mcp()`. The first instance is immediately replaced and garbage-collected.
The cost is negligible — `FastMCP.__init__` does no I/O, no network access, and no model loading.

Resolves #89 