### PR TITLE
fix: duplicate log records, save tool hint, and test interpreter

### DIFF
--- a/docling_mcp/logger.py
+++ b/docling_mcp/logger.py
@@ -9,8 +9,15 @@ def setup_logger() -> logging.Logger:
     logger = logging.getLogger("docling_mcp")
     logger.setLevel(logging.INFO)
 
+    # Repeated calls must not stack handlers, or every record is emitted
+    # once per module that called setup_logger(). Only this module's own
+    # handler counts; host-installed handlers do not suppress setup.
+    if any(h.name == "docling_mcp" for h in logger.handlers):
+        return logger
+
     # Create a handler and set its level to INFO
     handler = logging.StreamHandler()
+    handler.name = "docling_mcp"
     handler.setLevel(logging.INFO)
 
     # Create a formatter and add it to the handler
@@ -19,7 +26,9 @@ def setup_logger() -> logging.Logger:
     )
     handler.setFormatter(formatter)
 
-    # Add the handler to the logger
+    # Add the handler to the logger; records are fully handled here, so do
+    # not also propagate them to the root logger's handlers
     logger.addHandler(handler)
+    logger.propagate = False
 
     return logger

--- a/docling_mcp/tools/generation.py
+++ b/docling_mcp/tools/generation.py
@@ -136,7 +136,7 @@ class SaveDocumentOutput:
 
 @mcp.tool(
     title="Save Docling document",
-    annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
 )
 def save_docling_document(
     document_key: Annotated[


### PR DESCRIPTION
Three small fixes, split out of #113 so they can land on their own.

`setup_logger()` runs at import time in most modules and added another handler on every call, so one log record came out once per module that had called it.

`save_docling_document` writes a markdown and a JSON file into the cache directory, but was annotated `readOnlyHint=True`.

The test client launched the server with a bare `python`, which resolves against PATH rather than the interpreter running the tests. The e2e tests error out on main on my machine because of it.