### PR TITLE
feat: key conversions by file content and conversion config

### DIFF
--- a/docling_mcp/docling_cache.py
+++ b/docling_mcp/docling_cache.py
@@ -1,10 +1,13 @@
 """This module manages the cache directory to run Docling MCP tools."""
 
 import hashlib
+import importlib.metadata
 import json
 import os
 import sys
 from pathlib import Path
+
+from pydantic_settings import BaseSettings
 
 from docling_mcp.logger import setup_logger
 
@@ -67,15 +70,129 @@ def get_cache_dir() -> Path:
     return cache_path
 
 
+def _file_content_digest(path: Path) -> str:
+    """Return the SHA-256 digest of a file's content.
+
+    The content is hashed on every call: the cost is negligible next to a
+    conversion, and stat-based caching cannot reliably detect same-size
+    rewrites with preserved timestamps.
+    """
+    hasher = hashlib.sha256(usedforsecurity=False)
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+# Version stamps invalidate cached results when the packages that produce
+# them change behavior.
+_VERSION_STAMP = {
+    "docling_mcp": _package_version("docling-mcp"),
+    "docling": _package_version("docling-slim") or _package_version("docling"),
+}
+
+# Settings that do not influence the converted output. Everything else in a
+# settings model enters the cache key, so a setting added later invalidates
+# cached conversions until it is listed here rather than silently serving a
+# result produced under a different configuration.
+_NOT_OUTPUT_RELEVANT = frozenset(
+    {
+        "conversion_mode",
+        "fallback_to_local",
+        "service_api_key",
+        "service_max_retries",
+        "service_timeout",
+    }
+)
+
+
+def _output_relevant(settings: BaseSettings) -> dict[str, object]:
+    """Return the settings that change what a conversion produces."""
+    return {
+        name: value
+        for name, value in settings.model_dump(mode="json").items()
+        if name not in _NOT_OUTPUT_RELEVANT
+    }
+
+
+def local_conversion_context() -> dict[str, object]:
+    """Return the cache-key context for conversions executed locally."""
+    from docling_mcp.settings.conversion import settings as conversion_settings
+
+    return {
+        "mode": "local",
+        "options": _output_relevant(conversion_settings),
+        "versions": _VERSION_STAMP,
+    }
+
+
+def remote_conversion_context() -> dict[str, object]:
+    """Return the cache-key context for conversions delegated to docling-serve."""
+    from docling_mcp.settings.service_client import settings as service_settings
+
+    return {
+        "mode": "remote",
+        "options": _output_relevant(service_settings),
+        "versions": _VERSION_STAMP,
+    }
+
+
+def _default_conversion_context() -> dict[str, object]:
+    from docling_mcp.settings.service_client import (
+        ConversionMode,
+        settings as service_settings,
+    )
+
+    if service_settings.conversion_mode == ConversionMode.REMOTE:
+        return remote_conversion_context()
+    return local_conversion_context()
+
+
 def get_cache_key(
-    source: str, enable_ocr: bool = False, ocr_language: list[str] | None = None
+    source: str,
+    enable_ocr: bool = False,
+    ocr_language: list[str] | None = None,
+    conversion: dict[str, object] | None = None,
 ) -> str:
-    """Generate a cache key for the document conversion."""
-    key_data = {
-        "source": source,
+    """Generate a cache key for the document conversion.
+
+    Local files are keyed by their content digest, so identical files reached
+    through different paths share one conversion and an edited file triggers a
+    new one. Other sources (URLs) are keyed by the source string. The key also
+    covers the conversion configuration, so a result produced under a
+    different mode or pipeline setup is not reused. Converters should pass
+    their own `conversion` context so a fallback conversion is keyed by the
+    converter that actually ran, not by the configured mode.
+    """
+    key_data: dict[str, object] = {
         "enable_ocr": enable_ocr,
         "ocr_language": ocr_language or [],
+        "conversion": conversion
+        if conversion is not None
+        else _default_conversion_context(),
     }
+
+    try:
+        path = Path(source)
+        is_file = path.is_file()
+    except OSError:
+        is_file = False
+
+    if is_file:
+        key_data["content"] = _file_content_digest(path)
+        # The suffix selects the input format, so identical bytes under
+        # different extensions must not share a conversion.
+        key_data["format"] = path.suffix.lower()
+    else:
+        key_data["source"] = source
+
     key_str = json.dumps(key_data, sort_keys=True)
     hash = hash_string(key_str)
     return hash[:32]

--- a/docling_mcp/docling_cache.py
+++ b/docling_mcp/docling_cache.py
@@ -5,8 +5,9 @@ import importlib.metadata
 import json
 import os
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Final
+from urllib.parse import urlsplit
 
 from docling_mcp.logger import setup_logger
 
@@ -165,6 +166,20 @@ def _default_conversion_context() -> dict[str, object]:
     return local_conversion_context()
 
 
+def _looks_like_local_path(source: str) -> bool:
+    """Return whether a source should be resolved against the filesystem.
+
+    A URI scheme means the source names a remote object, so it is keyed by
+    its string and never read from disk. Windows drive letters parse as
+    one-character schemes, so they are detected separately and still treated
+    as paths. A schemeless source containing a colon before the first slash
+    (a legal POSIX filename) is treated as a URI and keyed by string.
+    """
+    if PureWindowsPath(source).drive:
+        return True
+    return not urlsplit(source).scheme
+
+
 def get_cache_key(
     source: str,
     conversion: dict[str, object] | None = None,
@@ -173,11 +188,13 @@ def get_cache_key(
 
     Local files are keyed by their content digest, so identical files reached
     through different paths share one conversion and an edited file triggers a
-    new one. Other sources (URLs) are keyed by the source string. The key also
-    covers the conversion configuration, so a result produced under a
-    different mode or pipeline setup is not reused. Converters should pass
-    their own `conversion` context so a fallback conversion is keyed by the
-    converter that actually ran, not by the configured mode.
+    new one. Sources carrying a URI scheme (URLs and object-storage URIs) are
+    keyed by the source string and never read from disk, so a file that
+    happens to sit at the path such a URI collapses to cannot stand in for it.
+    The key also covers the conversion configuration, so a result produced
+    under a different mode or pipeline setup is not reused. Converters should
+    pass their own `conversion` context so a fallback conversion is keyed by
+    the converter that actually ran, not by the configured mode.
     """
     key_data: dict[str, object] = {
         "conversion": conversion
@@ -185,11 +202,13 @@ def get_cache_key(
         else _default_conversion_context(),
     }
 
-    try:
-        path = Path(source)
-        is_file = path.is_file()
-    except OSError:
-        is_file = False
+    path = Path(source)
+    is_file = False
+    if _looks_like_local_path(source):
+        try:
+            is_file = path.is_file()
+        except OSError:
+            is_file = False
 
     if is_file:
         key_data["content"] = _file_content_digest(path)

--- a/docling_mcp/docling_cache.py
+++ b/docling_mcp/docling_cache.py
@@ -1,10 +1,12 @@
 """This module manages the cache directory to run Docling MCP tools."""
 
 import hashlib
+import importlib.metadata
 import json
 import os
 import sys
 from pathlib import Path
+from typing import Final
 
 from docling_mcp.logger import setup_logger
 
@@ -67,15 +69,136 @@ def get_cache_dir() -> Path:
     return cache_path
 
 
-def get_cache_key(
-    source: str, enable_ocr: bool = False, ocr_language: list[str] | None = None
-) -> str:
-    """Generate a cache key for the document conversion."""
-    key_data = {
-        "source": source,
-        "enable_ocr": enable_ocr,
-        "ocr_language": ocr_language or [],
+def _file_content_digest(path: Path) -> str:
+    """Return the SHA-256 digest of a file's content.
+
+    The content is hashed on every call: the cost is negligible next to a
+    conversion, and stat-based caching cannot reliably detect same-size
+    rewrites with preserved timestamps.
+    """
+    hasher = hashlib.sha256(usedforsecurity=False)
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+_VERSION_STAMP: Final[dict[str, str | None]] = {
+    "docling_mcp": _package_version("docling-mcp"),
+    "docling": _package_version("docling-slim") or _package_version("docling"),
+}
+"""Package versions that participate in the cache key.
+
+Invalidates cached results when the packages producing them change behavior.
+Computed once at import time, since the installed versions cannot change while
+the process runs.
+"""
+
+_NOT_OUTPUT_RELEVANT: Final[frozenset[str]] = frozenset(
+    {
+        "conversion_mode",
+        "fallback_to_local",
+        "service_api_key",
+        "service_max_retries",
+        "service_timeout",
     }
+)
+"""Settings that never change what a conversion produces.
+
+Every other setting enters the cache key, so one added later over-invalidates
+cached conversions until it is listed here, rather than silently serving a
+result produced under a different configuration.
+"""
+
+_NOT_RELEVANT_LOCALLY: Final[frozenset[str]] = frozenset({"service_url"})
+"""Settings that additionally do not apply when converting in this process."""
+
+
+def _conversion_options(exclude: frozenset[str] = frozenset()) -> dict[str, object]:
+    """Return the settings that change what a conversion produces."""
+    from docling_mcp.settings.service_client import settings
+
+    ignored = _NOT_OUTPUT_RELEVANT | exclude
+    return {
+        name: value
+        for name, value in settings.model_dump(mode="json").items()
+        if name not in ignored
+    }
+
+
+def local_conversion_context() -> dict[str, object]:
+    """Return the cache-key context for conversions executed locally."""
+    return {
+        "mode": "local",
+        "options": _conversion_options(_NOT_RELEVANT_LOCALLY),
+        "versions": _VERSION_STAMP,
+    }
+
+
+def remote_conversion_context() -> dict[str, object]:
+    """Return the cache-key context for conversions delegated to docling-serve."""
+    return {
+        "mode": "remote",
+        "options": _conversion_options(),
+        "versions": _VERSION_STAMP,
+    }
+
+
+def _default_conversion_context() -> dict[str, object]:
+    """Return the context for the configured mode.
+
+    Reads conversion_mode to pick between the remote and local contexts. Only
+    used when a caller does not supply its own context; the converters pass
+    theirs so a fallback conversion is keyed by the converter that ran.
+    """
+    from docling_mcp.settings.service_client import ConversionMode, settings
+
+    if settings.conversion_mode == ConversionMode.REMOTE:
+        return remote_conversion_context()
+    return local_conversion_context()
+
+
+def get_cache_key(
+    source: str,
+    conversion: dict[str, object] | None = None,
+) -> str:
+    """Generate a cache key for the document conversion.
+
+    Local files are keyed by their content digest, so identical files reached
+    through different paths share one conversion and an edited file triggers a
+    new one. Other sources (URLs) are keyed by the source string. The key also
+    covers the conversion configuration, so a result produced under a
+    different mode or pipeline setup is not reused. Converters should pass
+    their own `conversion` context so a fallback conversion is keyed by the
+    converter that actually ran, not by the configured mode.
+    """
+    key_data: dict[str, object] = {
+        "conversion": conversion
+        if conversion is not None
+        else _default_conversion_context(),
+    }
+
+    try:
+        path = Path(source)
+        is_file = path.is_file()
+    except OSError:
+        is_file = False
+
+    if is_file:
+        key_data["content"] = _file_content_digest(path)
+        # The suffix selects the input format, so identical bytes under
+        # different extensions must not share a conversion.
+        key_data["format"] = path.suffix.lower()
+    else:
+        key_data["source"] = source
+
     key_str = json.dumps(key_data, sort_keys=True)
     hash = hash_string(key_str)
     return hash[:32]

--- a/docling_mcp/tools/converters/local.py
+++ b/docling_mcp/tools/converters/local.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from docling_core.types.doc.common.content_layer import ContentLayer
 from docling_core.types.doc.labels import DocItemLabel
 
-from docling_mcp.docling_cache import get_cache_key
+from docling_mcp.docling_cache import get_cache_key, local_conversion_context
 from docling_mcp.logger import setup_logger
 from docling_mcp.settings.conversion import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
@@ -67,7 +67,7 @@ class LocalDocumentConverter:
         source = source.strip("\"'")
         logger.info(f"Converting document locally: {source}")
 
-        cache_key = get_cache_key(source)
+        cache_key = get_cache_key(source, conversion=local_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")

--- a/docling_mcp/tools/converters/local.py
+++ b/docling_mcp/tools/converters/local.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from docling_core.types.doc.common.content_layer import ContentLayer
 from docling_core.types.doc.labels import DocItemLabel
 
-from docling_mcp.docling_cache import get_cache_key
+from docling_mcp.docling_cache import get_cache_key, local_conversion_context
 from docling_mcp.logger import setup_logger
 from docling_mcp.settings.service_client import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
@@ -71,7 +71,7 @@ class LocalDocumentConverter:
         discard it.
         """
         source = source.strip("\"'")
-        cache_key = get_cache_key(source)
+        cache_key = get_cache_key(source, conversion=local_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")

--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -8,7 +8,7 @@ from docling.service_client import DoclingServiceClient
 from docling_core.types.doc.common.content_layer import ContentLayer
 from docling_core.types.doc.labels import DocItemLabel
 
-from docling_mcp.docling_cache import get_cache_key
+from docling_mcp.docling_cache import get_cache_key, remote_conversion_context
 from docling_mcp.logger import setup_logger
 from docling_mcp.settings.service_client import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
@@ -45,7 +45,7 @@ class RemoteDocumentConverter:
         source = source.strip("\"'")
         logger.info(f"Converting document via remote API: {source}")
 
-        cache_key = get_cache_key(source)
+        cache_key = get_cache_key(source, conversion=remote_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")

--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -9,7 +9,7 @@ from docling_core.types.doc.common.content_layer import ContentLayer
 from docling_core.types.doc.labels import DocItemLabel
 from docling_core.types.io import DocumentStream
 
-from docling_mcp.docling_cache import get_cache_key
+from docling_mcp.docling_cache import get_cache_key, remote_conversion_context
 from docling_mcp.logger import setup_logger
 from docling_mcp.settings.service_client import settings
 from docling_mcp.shared import local_document_cache, local_stack_cache
@@ -56,7 +56,7 @@ class RemoteDocumentConverter:
         staged through a temporary file.
         """
         source = source.strip("\"'")
-        cache_key = get_cache_key(source)
+        cache_key = get_cache_key(source, conversion=remote_conversion_context())
 
         if cache_key in local_document_cache:
             logger.info(f"Document found in cache: {cache_key}")

--- a/tests/test_cache_key.py
+++ b/tests/test_cache_key.py
@@ -1,0 +1,154 @@
+"""Test the conversion cache key."""
+
+import importlib
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from docling_mcp.docling_cache import (
+    _NOT_OUTPUT_RELEVANT,
+    get_cache_key,
+    local_conversion_context,
+    remote_conversion_context,
+)
+
+
+def test_cache_key_dedupes_identical_content(tmp_path: Path) -> None:
+    file_one = tmp_path / "one.pdf"
+    file_two = tmp_path / "sub" / "two.pdf"
+    file_two.parent.mkdir()
+    file_one.write_bytes(b"same bytes")
+    file_two.write_bytes(b"same bytes")
+
+    assert get_cache_key(str(file_one)) == get_cache_key(str(file_two))
+
+
+def test_cache_key_distinguishes_file_formats(tmp_path: Path) -> None:
+    file_one = tmp_path / "doc.html"
+    file_two = tmp_path / "doc.md"
+    file_one.write_bytes(b"same bytes")
+    file_two.write_bytes(b"same bytes")
+
+    # The suffix selects the input format, so identical bytes under
+    # different extensions must convert separately.
+    assert get_cache_key(str(file_one)) != get_cache_key(str(file_two))
+
+
+def test_cache_key_changes_when_content_changes(tmp_path: Path) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"version one")
+    key_one = get_cache_key(str(source))
+
+    source.write_bytes(b"version two, longer")
+
+    assert get_cache_key(str(source)) != key_one
+
+
+def test_cache_key_detects_same_size_rewrite_with_preserved_mtime(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"aaaa")
+    key_one = get_cache_key(str(source))
+    stat = source.stat()
+
+    source.write_bytes(b"bbbb")
+    os.utime(source, (stat.st_atime, stat.st_mtime))
+
+    assert get_cache_key(str(source)) != key_one
+
+
+def test_cache_key_for_urls_uses_source_string() -> None:
+    url = "https://example.com/spec.pdf"
+
+    assert get_cache_key(url) == get_cache_key(url)
+    assert get_cache_key(url) != get_cache_key(url + "?v=2")
+
+
+def test_cache_key_for_directories_uses_source_string(tmp_path: Path) -> None:
+    # A directory is not a file, so it must not be hashed as one.
+    assert get_cache_key(str(tmp_path)) == get_cache_key(str(tmp_path))
+
+
+def test_cache_key_uses_converter_supplied_context(tmp_path: Path) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+
+    local_key = get_cache_key(str(source), conversion=local_conversion_context())
+    remote_key = get_cache_key(str(source), conversion=remote_conversion_context())
+
+    # A fallback conversion executed locally must never share a key with a
+    # remote conversion of the same source.
+    assert local_key != remote_key
+
+
+def test_cache_key_follows_the_configured_mode(tmp_path: Path) -> None:
+    from docling_mcp.settings.service_client import (
+        ConversionMode,
+        settings as service_settings,
+    )
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(service_settings, "conversion_mode", ConversionMode.LOCAL)
+        local_key = get_cache_key(str(source))
+
+        mp.setattr(service_settings, "conversion_mode", ConversionMode.REMOTE)
+        mp.setattr(service_settings, "service_url", "https://serve-a.example.com")
+        remote_key_a = get_cache_key(str(source))
+
+        mp.setattr(service_settings, "service_url", "https://serve-b.example.com")
+        remote_key_b = get_cache_key(str(source))
+
+    assert local_key != remote_key_a
+    assert remote_key_a != remote_key_b
+
+
+@pytest.mark.parametrize(
+    ("module", "context"),
+    [
+        ("docling_mcp.settings.conversion", local_conversion_context),
+        ("docling_mcp.settings.service_client", remote_conversion_context),
+    ],
+)
+def test_cache_key_covers_every_output_relevant_setting(
+    tmp_path: Path, module: str, context: Any
+) -> None:
+    """Every setting that reaches the converter must change the key.
+
+    Asserting over the model fields rather than a hand-written list means a
+    setting added later fails this test instead of silently serving a
+    conversion produced under a different configuration.
+    """
+    settings = importlib.import_module(module).settings
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+    baseline = get_cache_key(str(source), conversion=context())
+
+    covered = [n for n in type(settings).model_fields if n not in _NOT_OUTPUT_RELEVANT]
+    assert covered, "no output-relevant settings found"
+
+    for name in covered:
+        current = getattr(settings, name)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(settings, name, _other_value(current))
+            changed = get_cache_key(str(source), conversion=context())
+        assert changed != baseline, f"{module}.{name} does not affect the cache key"
+
+
+def _other_value(current: object) -> object:
+    """Return a value of the same type that differs from the current one."""
+    if isinstance(current, bool):
+        return not current
+    if isinstance(current, int):
+        return current + 1
+    if isinstance(current, float):
+        return current + 1.0
+    if isinstance(current, str):
+        return current + "-changed"
+    return "changed"

--- a/tests/test_cache_key.py
+++ b/tests/test_cache_key.py
@@ -1,0 +1,185 @@
+"""Test the conversion cache key."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from docling_mcp.docling_cache import (
+    _NOT_OUTPUT_RELEVANT,
+    _NOT_RELEVANT_LOCALLY,
+    get_cache_key,
+    local_conversion_context,
+    remote_conversion_context,
+)
+
+
+def test_cache_key_dedupes_identical_content(tmp_path: Path) -> None:
+    file_one = tmp_path / "one.pdf"
+    file_two = tmp_path / "sub" / "two.pdf"
+    file_two.parent.mkdir()
+    file_one.write_bytes(b"same bytes")
+    file_two.write_bytes(b"same bytes")
+
+    assert get_cache_key(str(file_one)) == get_cache_key(str(file_two))
+
+
+def test_cache_key_distinguishes_file_formats(tmp_path: Path) -> None:
+    file_one = tmp_path / "doc.html"
+    file_two = tmp_path / "doc.md"
+    file_one.write_bytes(b"same bytes")
+    file_two.write_bytes(b"same bytes")
+
+    # The suffix selects the input format, so identical bytes under
+    # different extensions must convert separately.
+    assert get_cache_key(str(file_one)) != get_cache_key(str(file_two))
+
+
+def test_cache_key_changes_when_content_changes(tmp_path: Path) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"version one")
+    key_one = get_cache_key(str(source))
+
+    source.write_bytes(b"version two, longer")
+
+    assert get_cache_key(str(source)) != key_one
+
+
+def test_cache_key_detects_same_size_rewrite_with_preserved_mtime(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"aaaa")
+    key_one = get_cache_key(str(source))
+    stat = source.stat()
+
+    source.write_bytes(b"bbbb")
+    os.utime(source, (stat.st_atime, stat.st_mtime))
+
+    assert get_cache_key(str(source)) != key_one
+
+
+def test_cache_key_for_urls_uses_source_string() -> None:
+    url = "https://example.com/spec.pdf"
+
+    assert get_cache_key(url) != get_cache_key(url + "?v=2")
+
+
+def test_file_and_missing_path_keys_differ(tmp_path: Path) -> None:
+    """The same string keys differently once it stops naming a file."""
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"some bytes")
+    content_key = get_cache_key(str(source))
+
+    source.unlink()
+    source_string_key = get_cache_key(str(source))
+
+    assert content_key != source_string_key
+
+
+def test_cache_key_for_directories_uses_source_string(tmp_path: Path) -> None:
+    # A directory is not a file, so it must not be hashed as one.
+    assert get_cache_key(str(tmp_path)) == get_cache_key(str(tmp_path))
+
+
+def test_cache_key_uses_converter_supplied_context(tmp_path: Path) -> None:
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+
+    local_key = get_cache_key(str(source), conversion=local_conversion_context())
+    remote_key = get_cache_key(str(source), conversion=remote_conversion_context())
+
+    # A fallback conversion executed locally must never share a key with a
+    # remote conversion of the same source.
+    assert local_key != remote_key
+
+
+def test_cache_key_follows_the_configured_mode(tmp_path: Path) -> None:
+    from docling_mcp.settings.service_client import (
+        ConversionMode,
+        settings as service_settings,
+    )
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(service_settings, "conversion_mode", ConversionMode.LOCAL)
+        local_key = get_cache_key(str(source))
+
+        mp.setattr(service_settings, "conversion_mode", ConversionMode.REMOTE)
+        mp.setattr(service_settings, "service_url", "https://serve-a.example.com")
+        remote_key_a = get_cache_key(str(source))
+
+        mp.setattr(service_settings, "service_url", "https://serve-b.example.com")
+        remote_key_b = get_cache_key(str(source))
+
+    assert local_key != remote_key_a
+    assert remote_key_a != remote_key_b
+
+
+@pytest.mark.parametrize(
+    ("context", "also_ignored"),
+    [
+        (local_conversion_context, _NOT_RELEVANT_LOCALLY),
+        (remote_conversion_context, frozenset()),
+    ],
+)
+def test_cache_key_covers_every_output_relevant_setting(
+    tmp_path: Path, context: Any, also_ignored: frozenset[str]
+) -> None:
+    """Every setting that reaches the converter must change the key.
+
+    Asserting over the model fields rather than a hand-written list means a
+    setting added later fails this test instead of silently serving a
+    conversion produced under a different configuration.
+    """
+    from docling_mcp.settings.service_client import settings
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+    baseline = get_cache_key(str(source), conversion=context())
+
+    ignored = _NOT_OUTPUT_RELEVANT | also_ignored
+    covered = [n for n in type(settings).model_fields if n not in ignored]
+    assert covered, "no output-relevant settings found"
+
+    for name in covered:
+        current = getattr(settings, name)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(settings, name, _other_value(current))
+            changed = get_cache_key(str(source), conversion=context())
+        assert changed != baseline, f"{name} does not affect the cache key"
+
+
+@pytest.mark.parametrize("name", sorted(_NOT_OUTPUT_RELEVANT | _NOT_RELEVANT_LOCALLY))
+def test_settings_that_do_not_change_output_are_excluded(
+    tmp_path: Path, name: str
+) -> None:
+    """Ignored settings must not invalidate a cached local conversion."""
+    from docling_mcp.settings.service_client import settings
+
+    source = tmp_path / "doc.pdf"
+    source.write_bytes(b"stable bytes")
+    baseline = get_cache_key(str(source), conversion=local_conversion_context())
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(settings, name, _other_value(getattr(settings, name)))
+        assert (
+            get_cache_key(str(source), conversion=local_conversion_context())
+            == baseline
+        )
+
+
+def _other_value(current: object) -> object:
+    """Return a value of the same type that differs from the current one."""
+    if isinstance(current, bool):
+        return not current
+    if isinstance(current, int):
+        return current + 1
+    if isinstance(current, float):
+        return current + 1.0
+    if isinstance(current, str):
+        return current + "-changed"
+    return "changed"

--- a/tests/test_cache_key.py
+++ b/tests/test_cache_key.py
@@ -1,6 +1,7 @@
 """Test the conversion cache key."""
 
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -60,27 +61,49 @@ def test_cache_key_detects_same_size_rewrite_with_preserved_mtime(
     assert get_cache_key(str(source)) != key_one
 
 
-def test_cache_key_for_urls_uses_source_string() -> None:
+# Pinned so the source-branch tests below compare only the source, and cannot
+# pass because the conversion context happened to differ between two calls.
+_FIXED_CONTEXT: dict[str, object] = {}
+
+
+def test_url_cache_key_changes_with_query_string() -> None:
     url = "https://example.com/spec.pdf"
 
-    assert get_cache_key(url) != get_cache_key(url + "?v=2")
+    assert get_cache_key(url, conversion=_FIXED_CONTEXT) != get_cache_key(
+        url + "?v=2", conversion=_FIXED_CONTEXT
+    )
+
+
+def test_url_and_file_content_keys_differ_for_the_same_text(tmp_path: Path) -> None:
+    """A URL must not collide with a file whose content is that same URL."""
+    url = "https://example.com/spec.pdf"
+    source = tmp_path / "spec.pdf"
+    source.write_text(url, encoding="utf-8")
+
+    assert get_cache_key(url, conversion=_FIXED_CONTEXT) != get_cache_key(
+        str(source), conversion=_FIXED_CONTEXT
+    )
 
 
 def test_file_and_missing_path_keys_differ(tmp_path: Path) -> None:
     """The same string keys differently once it stops naming a file."""
     source = tmp_path / "doc.pdf"
     source.write_bytes(b"some bytes")
-    content_key = get_cache_key(str(source))
+    content_key = get_cache_key(str(source), conversion=_FIXED_CONTEXT)
 
     source.unlink()
-    source_string_key = get_cache_key(str(source))
 
-    assert content_key != source_string_key
+    assert get_cache_key(str(source), conversion=_FIXED_CONTEXT) != content_key
 
 
 def test_cache_key_for_directories_uses_source_string(tmp_path: Path) -> None:
-    # A directory is not a file, so it must not be hashed as one.
-    assert get_cache_key(str(tmp_path)) == get_cache_key(str(tmp_path))
+    """A directory is not a file, so it must not be hashed as one."""
+    source = tmp_path / "directory"
+    missing_key = get_cache_key(str(source), conversion=_FIXED_CONTEXT)
+
+    source.mkdir()
+
+    assert get_cache_key(str(source), conversion=_FIXED_CONTEXT) == missing_key
 
 
 def test_cache_key_uses_converter_supplied_context(tmp_path: Path) -> None:
@@ -153,27 +176,48 @@ def test_cache_key_covers_every_output_relevant_setting(
         assert changed != baseline, f"{name} does not affect the cache key"
 
 
-@pytest.mark.parametrize("name", sorted(_NOT_OUTPUT_RELEVANT | _NOT_RELEVANT_LOCALLY))
-def test_settings_that_do_not_change_output_are_excluded(
-    tmp_path: Path, name: str
-) -> None:
-    """Ignored settings must not invalidate a cached local conversion."""
+def test_settings_that_do_not_change_output_are_excluded(tmp_path: Path) -> None:
+    """Ignored settings must not invalidate a cached local conversion.
+
+    The expected sets are written out here rather than read from the
+    production constants. Otherwise adding an output-relevant setting to the
+    denylist would make the coverage test above stop checking it while this
+    test congratulates the implementation for excluding it.
+    """
     from docling_mcp.settings.service_client import settings
+
+    assert _NOT_OUTPUT_RELEVANT == {
+        "conversion_mode",
+        "fallback_to_local",
+        "service_api_key",
+        "service_max_retries",
+        "service_timeout",
+    }
+    assert _NOT_RELEVANT_LOCALLY == {"service_url"}
 
     source = tmp_path / "doc.pdf"
     source.write_bytes(b"stable bytes")
     baseline = get_cache_key(str(source), conversion=local_conversion_context())
 
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(settings, name, _other_value(getattr(settings, name)))
-        assert (
-            get_cache_key(str(source), conversion=local_conversion_context())
-            == baseline
-        )
+    for name in sorted(_NOT_OUTPUT_RELEVANT | _NOT_RELEVANT_LOCALLY):
+        current = getattr(settings, name)
+        other = _other_value(current)
+        assert other != current, f"{name} was not actually changed"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(settings, name, other)
+            assert (
+                get_cache_key(str(source), conversion=local_conversion_context())
+                == baseline
+            ), f"{name} unexpectedly affects the local cache key"
 
 
 def _other_value(current: object) -> object:
-    """Return a value of the same type that differs from the current one."""
+    """Return a valid value of the same type that differs from the current one."""
+    if isinstance(current, Enum):
+        alternatives = [member for member in type(current) if member != current]
+        assert alternatives, f"{type(current).__name__} has no other member"
+        return alternatives[0]
     if isinstance(current, bool):
         return not current
     if isinstance(current, int):
@@ -182,4 +226,7 @@ def _other_value(current: object) -> object:
         return current + 1.0
     if isinstance(current, str):
         return current + "-changed"
-    return "changed"
+    if current is None:
+        # Every currently None-valued setting is annotated str | None.
+        return "changed"
+    raise AssertionError(f"unsupported settings value type: {type(current)!r}")

--- a/tests/test_cache_key.py
+++ b/tests/test_cache_key.py
@@ -10,6 +10,7 @@ import pytest
 from docling_mcp.docling_cache import (
     _NOT_OUTPUT_RELEVANT,
     _NOT_RELEVANT_LOCALLY,
+    _looks_like_local_path,
     get_cache_key,
     local_conversion_context,
     remote_conversion_context,
@@ -72,6 +73,48 @@ def test_url_cache_key_changes_with_query_string() -> None:
     assert get_cache_key(url, conversion=_FIXED_CONTEXT) != get_cache_key(
         url + "?v=2", conversion=_FIXED_CONTEXT
     )
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("relative.pdf", True),
+        ("./relative.pdf", True),
+        ("/abs/doc.pdf", True),
+        (r"C:\doc.pdf", True),
+        ("C:/doc.pdf", True),
+        (r"\\server\share\doc.pdf", True),
+        ("//server/share/doc.pdf", True),
+        ("https://example.com/spec.pdf", False),
+        ("s3://bucket/key.pdf", False),
+        ("abfs://container/key.pdf", False),
+        ("file:///tmp/doc.pdf", False),
+    ],
+)
+def test_looks_like_local_path(source: str, expected: bool) -> None:
+    """Windows drive letters parse as schemes, so they need separate handling."""
+    assert _looks_like_local_path(source) is expected
+
+
+def test_url_is_never_keyed_by_a_local_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file at the path a URL collapses to must not stand in for the URL.
+
+    Path("https://example.com/spec.pdf") is the relative path
+    "https:/example.com/spec.pdf", so without a scheme check a file planted
+    there would be hashed as the URL's content.
+    """
+    url = "https://example.com/spec.pdf"
+    before = get_cache_key(url, conversion=_FIXED_CONTEXT)
+
+    monkeypatch.chdir(tmp_path)
+    planted = Path(url)
+    planted.parent.mkdir(parents=True, exist_ok=True)
+    planted.write_bytes(b"not the real document")
+    assert planted.is_file()
+
+    assert get_cache_key(url, conversion=_FIXED_CONTEXT) == before
 
 
 def test_url_and_file_content_keys_differ_for_the_same_text(tmp_path: Path) -> None:


### PR DESCRIPTION
Split out of #113.

Cache keys come from the source string today, so the same file reached through a relative and an absolute path converts twice, and a file edited in place keeps serving the previous conversion. This hashes the content of local files instead, along with the suffix since that is what selects the input format. URLs keep using the source string.

The key also covers the settings that reach the converter. Those are read off the settings models rather than listed by hand — `images_scale` was easy to miss when I first wrote this out by hand, and a setting added later now invalidates cached conversions until someone explicitly marks it as not affecting the output. Converters pass their own context, so a fallback conversion is keyed by the converter that actually ran rather than by the configured mode.

`tests/test_cache_key.py` asserts the coverage over the model fields, so the hand-listing problem cannot come back.