### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fdocling-project%2Fdocling-mcp.svg)](https://mcptoplist.com/server/glama%2Fdocling-project%2Fdocling-mcp)
+
 <p align="center">
   <a href="https://github.com/docling-project/docling-mcp">
     <img loading="lazy" alt="Docling" src="https://github.com/docling-project/docling-mcp/raw/main/docs/assets/docling_mcp.png" width="40%"/>


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **Docling MCP** is currently ranked **#988**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fdocling-project%2Fdocling-mcp.svg)](https://mcptoplist.com/server/glama%2Fdocling-project%2Fdocling-mcp)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Docling MCP!
