### PR TITLE
ci: publish to the official MCP Registry on release

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -13,6 +13,17 @@ CHGLOG_FILE="${CHGLOG_FILE:-CHANGELOG.md}"
 uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version "${TARGET_VERSION}"
 uv lock --upgrade-package docling-mcp
 
+# keep server.json version in sync
+python3 -c "
+import json, pathlib
+p = pathlib.Path('server.json')
+s = json.loads(p.read_text())
+s['version'] = '${TARGET_VERSION}'
+s['packages'][0]['version'] = '${TARGET_VERSION}'
+s['packages'][0]['runtimeArguments'][0]['value'] = 'docling-mcp==${TARGET_VERSION}'
+p.write_text(json.dumps(s, indent=2) + '\n')
+"
+
 # collect release notes
 REL_NOTES=$(mktemp)
 uv run --no-sync semantic-release changelog --unreleased >> "${REL_NOTES}"
@@ -31,7 +42,7 @@ mv "${TMP_CHGLOG}" "${CHGLOG_FILE}"
 # push changes
 git config --global user.name 'github-actions[bot]'
 git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-git add pyproject.toml uv.lock "${CHGLOG_FILE}"
+git add pyproject.toml uv.lock "${CHGLOG_FILE}" server.json
 COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
 git commit -m "${COMMIT_MSG}"
 git push origin main

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,69 @@
+name: Publish to MCP Registry
+
+# Publishes server.json to the official MCP Registry (registry.modelcontextprotocol.io)
+# via GitHub OIDC — no stored token required. The `io.github.docling-project/*` namespace
+# is authorised because this workflow runs in the docling-project org. The release workflow
+# calls this after PyPI and the GitHub Release succeed; maintainers can also trigger it manually.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Immutable release ref whose server.json should be published
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref whose server.json should be published
+        required: true
+        default: main
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-mcp:
+    name: Publish server.json to the MCP Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Wait for PyPI to serve the release with the ownership marker
+        run: |
+          ver="$(python3 -c "import json;print(json.load(open('server.json'))['version'])")"
+          name="$(python3 -c "import json;print(json.load(open('server.json'))['name'])")"
+          echo "Waiting for PyPI docling-mcp ${ver} with marker 'mcp-name: ${name}'"
+          for i in $(seq 1 40); do
+            desc="$(curl -sf "https://pypi.org/pypi/docling-mcp/${ver}/json" \
+              | python3 -c "import sys,json;print(json.load(sys.stdin)['info']['description'])" 2>/dev/null || true)"
+            if printf '%s' "$desc" | grep -q "mcp-name: ${name}"; then
+              echo "Ownership marker present on PyPI ${ver}"; exit 0
+            fi
+            echo "Attempt ${i}/40: not yet — sleeping 20s"; sleep 20
+          done
+          echo "::error::PyPI ${ver} with the ownership marker was not found in time"; exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          version="1.8.0"
+          archive="mcp-publisher_linux_amd64.tar.gz"
+          expected_sha256="1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf"
+          url="https://github.com/modelcontextprotocol/registry/releases/download/v${version}/${archive}"
+          curl --fail --location --proto '=https' --tlsv1.2 "$url" --output "$archive"
+          printf '%s  %s\n' "$expected_sha256" "$archive" | sha256sum --check --strict
+          tar --extract --gzip --file "$archive" mcp-publisher
+          chmod 0755 mcp-publisher
+          ./mcp-publisher --version
+
+      - name: Authenticate to the MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Validate and publish server.json
+        run: |
+          ./mcp-publisher validate server.json
+          ./mcp-publisher publish

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/docling-mcp  # Replace <package-name> with your PyPI project name
+      url: https://pypi.org/p/docling-mcp
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
@@ -32,3 +32,14 @@ jobs:
         with:
           # generating signed digital attestations currently not working with reusable workflows
           attestations: false
+
+  publish-mcp:
+    name: Publish to MCP Registry
+    needs:
+      - build-and-publish
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-mcp.yml
+    with:
+      ref: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![License MIT](https://img.shields.io/github/license/docling-project/docling-mcp)](https://opensource.org/licenses/MIT)
 [![PyPI Downloads](https://static.pepy.tech/badge/docling-mcp/month)](https://pepy.tech/projects/docling-mcp)
 [![LF AI & Data](https://img.shields.io/badge/LF%20AI%20%26%20Data-003778?logo=linuxfoundation&logoColor=fff&color=0094ff&labelColor=003778)](https://lfaidata.foundation/projects/)
-[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-listed-8b5cf6.svg)](https://registry.modelcontextprotocol.io/servers/io.github.docling-project-docling-mcp)
+[![MCP Registry](https://img.shields.io/badge/listed_in-MCP_Registry-green?logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io)
 
 A document processing service using the Docling-MCP library and MCP (Model Context Protocol) for tool integration.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![License MIT](https://img.shields.io/github/license/docling-project/docling-mcp)](https://opensource.org/licenses/MIT)
 [![PyPI Downloads](https://static.pepy.tech/badge/docling-mcp/month)](https://pepy.tech/projects/docling-mcp)
 [![LF AI & Data](https://img.shields.io/badge/LF%20AI%20%26%20Data-003778?logo=linuxfoundation&logoColor=fff&color=0094ff&labelColor=003778)](https://lfaidata.foundation/projects/)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-listed-8b5cf6.svg)](https://registry.modelcontextprotocol.io/servers/io.github.docling-project-docling-mcp)
 
 A document processing service using the Docling-MCP library and MCP (Model Context Protocol) for tool integration.
 
@@ -258,3 +259,6 @@ Docling and Docling MCP is hosted as a project in the [LF AI & Data Foundation](
 
 [docling_document]: https://docling-project.github.io/docling/concepts/docling_document/
 [integrations]: https://docling-project.github.io/docling-mcp/integrations/
+
+<!-- MCP registry ownership marker (proves this PyPI package maps to the server name). -->
+<!-- mcp-name: io.github.docling-project/docling-mcp -->

--- a/server.json
+++ b/server.json
@@ -23,26 +23,62 @@
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {
-          "name": "DOCLING_SERVICE_URL",
-          "description": "Base URL of the Docling Serve instance. Required for remote conversion mode.",
+          "name": "DOCLING_MCP_CONVERSION_MODE",
+          "description": "Conversion mode: 'remote' (default) or 'local' (requires docling-mcp[local] extra).",
           "isRequired": false,
           "isSecret": false
         },
         {
-          "name": "DOCLING_SERVICE_API_KEY",
+          "name": "DOCLING_MCP_SERVICE_URL",
+          "description": "Base URL of the Docling Serve instance. Required when conversion mode is remote.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_MCP_SERVICE_API_KEY",
           "description": "API key for authenticating with Docling Serve.",
           "isRequired": false,
           "isSecret": true
         },
         {
-          "name": "DOCLING_CONVERSION_MODE",
-          "description": "Conversion mode: 'remote' (default), 'local' (needs [local] extra), or 'hybrid'.",
+          "name": "DOCLING_MCP_SERVICE_TIMEOUT",
+          "description": "Request timeout in seconds for the remote Docling Serve API. Default: 300.0.",
           "isRequired": false,
           "isSecret": false
         },
         {
-          "name": "DOCLING_FALLBACK_TO_LOCAL",
+          "name": "DOCLING_MCP_SERVICE_MAX_RETRIES",
+          "description": "Maximum number of retry attempts for remote API requests. Default: 3.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_MCP_FALLBACK_TO_LOCAL",
           "description": "Set to 'true' to fall back to local conversion when Docling Serve is unreachable.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_MCP_KEEP_IMAGES",
+          "description": "Set to 'true' to retain page images in converted documents. Default: false.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_MCP_IMAGES_SCALE",
+          "description": "Image scale factor (e.g. 1.0, 2.0). Increase to avoid tensor batching errors. Default: 1.0.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_MCP_DO_OCR",
+          "description": "Set to 'false' to disable the OCR pipeline. Default: true.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_MCP_DO_TABLE_STRUCTURE",
+          "description": "Set to 'false' to disable table structure detection. Default: true.",
           "isRequired": false,
           "isSecret": false
         }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.docling-project/docling-mcp",
+  "title": "Docling MCP",
+  "description": "Convert PDFs and other documents to structured formats via Docling, for AI applications.",
+  "repository": {
+    "url": "https://github.com/docling-project/docling-mcp",
+    "source": "github"
+  },
+  "version": "2.2.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "docling-mcp",
+      "version": "2.2.0",
+      "runtimeHint": "uvx",
+      "runtimeArguments": [
+        { "type": "named", "name": "--from", "value": "docling-mcp==2.2.0" },
+        { "type": "positional", "value": "docling-mcp-server" },
+        { "type": "named", "name": "--transport", "value": "stdio" }
+      ],
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        {
+          "name": "DOCLING_SERVICE_URL",
+          "description": "Base URL of the Docling Serve instance. Required for remote conversion mode.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_SERVICE_API_KEY",
+          "description": "API key for authenticating with Docling Serve.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "DOCLING_CONVERSION_MODE",
+          "description": "Conversion mode: 'remote' (default), 'local' (needs [local] extra), or 'hybrid'.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "DOCLING_FALLBACK_TO_LOCAL",
+          "description": "Set to 'true' to fall back to local conversion when Docling Serve is unreachable.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Registers docling-mcp with the [official MCP Registry](https://registry.modelcontextprotocol.io)
and automates re-publication on every release.

## Changes

- **`server.json`** — MCP Registry manifest declaring the server name
  (`io.github.docling-project/docling-mcp`), PyPI package coordinates, `uvx` runtime
  invocation, and all supported environment variables.
- **`README.md`** — adds an MCP Registry badge and an HTML ownership marker comment
  (`<!-- mcp-name: … -->`) required by the registry to prove this PyPI package maps to
  the declared server name.
- **`.github/workflows/publish-mcp.yml`** — reusable workflow that authenticates to the
  MCP Registry via GitHub OIDC (no stored token), waits for PyPI to serve the new release
  with the ownership marker, then validates and publishes `server.json`.
- **`.github/workflows/pypi.yml`** — adds a `publish-mcp` job that calls the new workflow
  automatically after `build-and-publish` succeeds.

## Release pipeline (after this PR)

GitHub Release published
└─ build-package
└─ build-and-publish  →  PyPI
└─ publish-mcp   →  MCP Registry


## Notes

- Authentication uses **GitHub OIDC** — no secrets need to be added to the repo.
  The `io.github.docling-project/*` namespace is automatically authorised because the
  workflow runs inside the `docling-project` GitHub org.
- `mcp-publisher` is downloaded with a pinned SHA-256 checksum to prevent supply-chain
  tampering.
- The "wait for PyPI" step (up to ~13 min) prevents a race between the PyPI publish and
  the registry publish.
- `server.json` versions are updated automatically by the release script alongside `pyproject.toml`.
- The `publish-mcp.yml` workflow can also be triggered manually via `workflow_dispatch`
  for reruns or corrections.