### PR TITLE
fix(prompts): use summary-only description, use Annotated pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 # Docling MCP: making docling agentic
 
+[![CI](https://github.com/docling-project/docling-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/docling-project/docling-mcp/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/docling-mcp)](https://pypi.org/project/docling-mcp/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/docling-mcp)](https://pypi.org/project/docling-mcp/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -15,7 +16,7 @@
 [![License MIT](https://img.shields.io/github/license/docling-project/docling-mcp)](https://opensource.org/licenses/MIT)
 [![PyPI Downloads](https://static.pepy.tech/badge/docling-mcp/month)](https://pepy.tech/projects/docling-mcp)
 [![LF AI & Data](https://img.shields.io/badge/LF%20AI%20%26%20Data-003778?logo=linuxfoundation&logoColor=fff&color=0094ff&labelColor=003778)](https://lfaidata.foundation/projects/)
-[![MCP Registry](https://img.shields.io/badge/listed_in-MCP_Registry-green?logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-green?logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io)
 
 A document processing service using the Docling-MCP library and MCP (Model Context Protocol) for tool integration.
 

--- a/docling_mcp/prompts/conversion.py
+++ b/docling_mcp/prompts/conversion.py
@@ -1,17 +1,24 @@
 """Prompts for converting documents with Docling."""
 
+from typing import Annotated
+
+from pydantic import Field
+
 from docling_mcp.shared import mcp
 
 
-@mcp.prompt()
-def generate_docling_document_from_pdf(file_path: str) -> str:
-    """Convert a local PDF file into a Docling document and return its document key.
-
-    Args:
-        file_path: The absolute or relative path to a local PDF file.
-    """
+@mcp.prompt(title="Convert document")
+def generate_docling_document_from_pdf(
+    file_path: Annotated[
+        str,
+        Field(
+            description="The absolute or relative path to a local file (PDF, DOCX, XLSX, HTML, Markdown, EPUB, …)."
+        ),
+    ],
+) -> str:
+    """Convert a local file into a Docling document and return its document key."""
     return (
-        f"Convert the PDF file at '{file_path}' into a Docling document by calling "
+        f"Convert the file at '{file_path}' into a Docling document by calling "
         "convert_document_into_docling_document with the file path as the source. "
         "Once conversion is complete, return the document_key so I can use it with "
         "other tools. Also confirm whether the document was served from cache "
@@ -19,13 +26,13 @@ def generate_docling_document_from_pdf(file_path: str) -> str:
     )
 
 
-@mcp.prompt()
-def convert_and_summarize(source: str) -> str:
-    """Convert a document and produce a structured summary.
-
-    Args:
-        source: The URL or local file path to the document.
-    """
+@mcp.prompt(title="Convert and summarize")
+def convert_and_summarize(
+    source: Annotated[
+        str, Field(description="The URL or local file path to the document.")
+    ],
+) -> str:
+    """Convert a document and produce a structured summary."""
     return (
         f"Convert the document at '{source}' by calling "
         "convert_document_into_docling_document. "
@@ -38,13 +45,13 @@ def convert_and_summarize(source: str) -> str:
     )
 
 
-@mcp.prompt()
-def convert_directory_and_list(directory: str) -> str:
-    """Convert all files in a directory and list the results.
-
-    Args:
-        directory: The path to a local directory containing documents.
-    """
+@mcp.prompt(title="Convert directory")
+def convert_directory_and_list(
+    directory: Annotated[
+        str, Field(description="The path to a local directory containing documents.")
+    ],
+) -> str:
+    """Convert all files in a directory and list the results."""
     return (
         f"Convert all files in the directory '{directory}' by calling "
         "convert_directory_files_into_docling_document. "

--- a/docling_mcp/prompts/generation.py
+++ b/docling_mcp/prompts/generation.py
@@ -1,16 +1,20 @@
 """Prompts for generating and rewriting Docling documents."""
 
+from typing import Annotated
+
+from pydantic import Field
+
 from docling_mcp.shared import mcp
 
 
-@mcp.prompt()
-def author_structured_document(topic: str, sections: str) -> str:
-    """Create a new structured Docling document on a given topic.
-
-    Args:
-        topic: The subject of the document to write.
-        sections: Comma-separated list of section headings to include.
-    """
+@mcp.prompt(title="Author structured document")
+def author_structured_document(
+    topic: Annotated[str, Field(description="The subject of the document to write.")],
+    sections: Annotated[
+        str, Field(description="Comma-separated list of section headings to include.")
+    ],
+) -> str:
+    """Create a new structured Docling document on a given topic."""
     return (
         f"Write a well-structured Docling document about '{topic}' "
         f"with the following sections: {sections}. "
@@ -28,15 +32,19 @@ def author_structured_document(topic: str, sections: str) -> str:
     )
 
 
-@mcp.prompt()
-def convert_and_rewrite(source: str, instructions: str) -> str:
-    """Convert a document and rewrite its content following specific instructions.
-
-    Args:
-        source: The URL or local file path to the source document.
-        instructions: Rewriting instructions, e.g. 'translate to French' or
-            'simplify for a non-technical audience'.
-    """
+@mcp.prompt(title="Convert and rewrite")
+def convert_and_rewrite(
+    source: Annotated[
+        str, Field(description="The URL or local file path to the source document.")
+    ],
+    instructions: Annotated[
+        str,
+        Field(
+            description="Rewriting instructions, e.g. 'translate to French' or 'simplify for a non-technical audience'."
+        ),
+    ],
+) -> str:
+    """Convert a document and rewrite its content following specific instructions."""
     return (
         f"Convert the document at '{source}' and rewrite it following these instructions: "
         f"{instructions}\n\n"

--- a/docling_mcp/prompts/manipulation.py
+++ b/docling_mcp/prompts/manipulation.py
@@ -1,15 +1,20 @@
 """Prompts for editing and searching Docling documents."""
 
+from typing import Annotated
+
+from pydantic import Field
+
 from docling_mcp.shared import mcp
 
 
-@mcp.prompt()
-def review_and_edit_document(document_key: str) -> str:
-    """Review the structure of a cached document and interactively edit it.
-
-    Args:
-        document_key: The unique identifier of the document in the local cache.
-    """
+@mcp.prompt(title="Review and edit")
+def review_and_edit_document(
+    document_key: Annotated[
+        str,
+        Field(description="The unique identifier of the document in the local cache."),
+    ],
+) -> str:
+    """Review the structure of a cached document and interactively edit it."""
     return (
         f"I want to review and edit the document with key '{document_key}'.\n\n"
         "Start by calling get_overview_of_document_anchors to display the full document "
@@ -23,17 +28,16 @@ def review_and_edit_document(document_key: str) -> str:
     )
 
 
-@mcp.prompt()
+@mcp.prompt(title="Find and replace")
 def find_and_replace_in_document(
-    document_key: str, search_text: str, replacement_text: str
+    document_key: Annotated[
+        str,
+        Field(description="The unique identifier of the document in the local cache."),
+    ],
+    search_text: Annotated[str, Field(description="The text to search for.")],
+    replacement_text: Annotated[str, Field(description="The text to replace it with.")],
 ) -> str:
-    """Find text in a cached document and replace it at the correct anchor.
-
-    Args:
-        document_key: The unique identifier of the document in the local cache.
-        search_text: The text to search for.
-        replacement_text: The text to replace it with.
-    """
+    """Find text in a cached document and replace it at the correct anchor."""
     return (
         f"In the document with key '{document_key}', find '{search_text}' "
         f"and replace it with '{replacement_text}'.\n\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from typing import Any, TypeVar
 
 import pytest
 from mcp import Client, Tool
-from mcp.types import CallToolResult
+from mcp.types import CallToolResult, Prompt
 
 _T = TypeVar("_T")
 
@@ -51,6 +51,10 @@ class MCPClient:
     async def get_tools(self) -> list[Tool]:
         response = await self._async_call(self._client.list_tools())
         return response.tools
+
+    async def list_prompts(self) -> list[Prompt]:
+        response = await self._async_call(self._client.list_prompts())
+        return response.prompts
 
     async def call_tool(
         self, tool_name: str, arguments: dict[str, Any] | None = None

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,79 @@
+"""Test that registered prompts have correct metadata."""
+
+import pytest
+
+from tests.conftest import MCPClient
+
+# Expected prompts: name -> (title, single-line description, argument names)
+_EXPECTED_PROMPTS = {
+    "generate_docling_document_from_pdf": (
+        "Convert document",
+        "Convert a local file into a Docling document and return its document key.",
+        ["file_path"],
+    ),
+    "convert_and_summarize": (
+        "Convert and summarize",
+        "Convert a document and produce a structured summary.",
+        ["source"],
+    ),
+    "convert_directory_and_list": (
+        "Convert directory",
+        "Convert all files in a directory and list the results.",
+        ["directory"],
+    ),
+    "author_structured_document": (
+        "Author structured document",
+        "Create a new structured Docling document on a given topic.",
+        ["topic", "sections"],
+    ),
+    "convert_and_rewrite": (
+        "Convert and rewrite",
+        "Convert a document and rewrite its content following specific instructions.",
+        ["source", "instructions"],
+    ),
+    "review_and_edit_document": (
+        "Review and edit",
+        "Review the structure of a cached document and interactively edit it.",
+        ["document_key"],
+    ),
+    "find_and_replace_in_document": (
+        "Find and replace",
+        "Find text in a cached document and replace it at the correct anchor.",
+        ["document_key", "search_text", "replacement_text"],
+    ),
+}
+
+
+@pytest.mark.anyio
+async def test_prompt_metadata(mcp_client: MCPClient) -> None:
+    """Prompt descriptions are single-line and arguments carry their own descriptions."""
+    prompts = await mcp_client.list_prompts()
+    by_name = {p.name: p for p in prompts}
+
+    assert set(by_name) == set(_EXPECTED_PROMPTS), (
+        f"Unexpected prompt names: {set(by_name) - set(_EXPECTED_PROMPTS)}"
+    )
+
+    for name, (title, description, arg_names) in _EXPECTED_PROMPTS.items():
+        prompt = by_name[name]
+
+        # Description must be exactly the summary line — no newlines, no "Args:" section.
+        assert "\n" not in (prompt.description or ""), (
+            f"Prompt '{name}' description contains newlines: {prompt.description!r}"
+        )
+        assert (prompt.description or "").strip() == description, (
+            f"Prompt '{name}' description mismatch"
+        )
+
+        # Title is set explicitly via @mcp.prompt(title=...).
+        assert prompt.title == title, f"Prompt '{name}' title mismatch"
+
+        # Every argument must carry a non-empty description (from Field(description=...)).
+        actual_arg_names = [a.name for a in (prompt.arguments or [])]
+        assert actual_arg_names == arg_names, (
+            f"Prompt '{name}' argument names mismatch: {actual_arg_names} != {arg_names}"
+        )
+        for arg in prompt.arguments or []:
+            assert arg.description, (
+                f"Prompt '{name}', argument '{arg.name}' has no description"
+            )


### PR DESCRIPTION
Resolves #127 

## Problem

The `description` field of every MCP prompt registered with `@mcp.prompt()` contained
the function's **full docstring**, including the `Args:` section. For example:

```
Convert a local PDF file into a Docling document and return its document key.
Args:
    file_path: The absolute or relative path to a local PDF file.
```

MCP clients that render prompt descriptions in a command palette (e.g. opencode's `/`
slash-command autocomplete) displayed the entire block verbatim — 5–6 lines per prompt —
making the palette unusable when several prompts were registered.

The `Args:` content was also redundant: the MCP protocol already carries parameter
metadata in the structured `arguments` field of each prompt, but that field was empty
because no typed argument descriptions were provided.

## Changes

- **`@mcp.prompt(title=...)`** — every prompt now has an explicit, short human-readable
  title suitable for a button label (e.g. `"Convert document"`, `"Find and replace"`).

- **`Annotated[str, Field(description=...)]`** on every parameter — argument descriptions
  are now carried in the structured `arguments` field of the prompt, exactly as the
  [MCP SDK documentation](https://py.sdk.modelcontextprotocol.io/servers/prompts/#titles-and-argument-descriptions)
  prescribes. The `Args:` section is removed from all docstrings.

- **Docstrings trimmed to one summary line** — the prompt `description` field now
  contains only the concise one-liner, rendering as a single line in any client UI.

- **`generate_docling_document_from_pdf` de-PDF-ified** — the title, parameter
  description, docstring, and prompt body text all previously referred exclusively to
  PDF files. Docling supports many formats (PDF, DOCX, XLSX, HTML, Markdown, EPUB, …),
  so all PDF-specific wording has been replaced with format-agnostic language.

- **`tests/test_prompts.py`** (new) — verifies for every registered prompt that the
  description is a single line, the title matches, each argument is present, and every
  argument carries a non-empty description.

- **`tests/conftest.py`** — adds a `list_prompts()` helper on `MCPClient` to support
  the new test.
