### PR TITLE
chore: claim the MCP server to Glama

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![PyPI Downloads](https://static.pepy.tech/badge/docling-mcp/month)](https://pepy.tech/projects/docling-mcp)
 [![LF AI & Data](https://img.shields.io/badge/LF%20AI%20%26%20Data-003778?logo=linuxfoundation&logoColor=fff&color=0094ff&labelColor=003778)](https://lfaidata.foundation/projects/)
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-green?logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io)
+[![docling-mcp MCP server](https://glama.ai/mcp/servers/docling-project/docling-mcp/badges/score.svg)](https://glama.ai/mcp/servers/docling-project/docling-mcp)
 
 A document processing service using the Docling-MCP library and MCP (Model Context Protocol) for tool integration.
 

--- a/docling_mcp/glama.json
+++ b/docling_mcp/glama.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "PeterStaar-IBM",
+    "zanetworker",
+    "dolfim-ibm",
+    "vagenas",
+    "cau-git",
+    "ceberam"
+  ]
+}


### PR DESCRIPTION
- This PR follows the instructions on [What is glama.json?](https://glama.ai/blog/2025-07-08-what-is-glamajson) to claim this MCP server to [Glama](https://glama.ai/), a superset of the [official MCP Registry](https://registry.modelcontextprotocol.io/)
- In addition, it adds the Glama badge on README file