### PR TITLE
fix: code quality, error handling, and docstring improvements

### DIFF
--- a/docling_mcp/docling_cache.py
+++ b/docling_mcp/docling_cache.py
@@ -16,20 +16,33 @@ logger = setup_logger()
 
 
 def hash_string(input_string: str) -> str:
-    """Creates a hash-string from the input string."""
+    """Create a SHA-256 hex-digest string from the input.
+
+    Args:
+        input_string: The string to hash.
+
+    Returns:
+        A 64-character lowercase hex string.
+    """
     return hashlib.sha256(input_string.encode(), usedforsecurity=False).hexdigest()
 
 
 def get_cache_dir() -> Path:
-    """Get the cache directory for the application.
+    """Return the cache directory for the application, creating it if needed.
+
+    Resolution order:
+
+    1. `CACHE_DIR` environment variable — used as-is when set.
+    2. PyInstaller frozen executable — a `_cache` directory next to the
+       executable.
+    3. Normal interpreter — walks up from the caller's `__file__` to find
+       the highest ancestor directory that still contains an `__init__.py`,
+       then places `_cache` one level above it (i.e., at the package root).
+       Falls back to the current working directory when `__file__` is
+       unavailable.
 
     Returns:
-        Path: A Path object pointing to the cache directory.
-
-    The function will:
-    1. First check for an environment variable 'CACHE_DIR'
-    2. If not found, create a '_cache' directory in the root of the current package
-    3. Ensure the directory exists before returning
+        A `Path` pointing to an existing cache directory.
     """
     # Check if cache directory is specified in environment variable
     cache_dir = os.environ.get("CACHE_DIR")
@@ -85,6 +98,14 @@ def _file_content_digest(path: Path) -> str:
 
 
 def _package_version(name: str) -> str | None:
+    """Return the installed version of `name`, or `None` if not found.
+
+    Args:
+        name: The distribution package name to look up.
+
+    Returns:
+        The version string, or `None` when the package is not installed.
+    """
     try:
         return importlib.metadata.version(name)
     except importlib.metadata.PackageNotFoundError:
@@ -219,5 +240,5 @@ def get_cache_key(
         key_data["source"] = source
 
     key_str = json.dumps(key_data, sort_keys=True)
-    hash = hash_string(key_str)
-    return hash[:32]
+    cache_hash = hash_string(key_str)
+    return cache_hash[:32]

--- a/docling_mcp/settings/llama_index.py
+++ b/docling_mcp/settings/llama_index.py
@@ -1,20 +1,37 @@
 """This module contains the settings for the Llama Index usages."""
 
+from typing import Annotated
+
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """Settings for the Llama Index usages."""
+    """Settings for Llama Index tool integrations.
+
+    All settings are read from environment variables with the
+    `DOCLING_MCP_LI_` prefix (or from a `.env` file).
+    """
 
     model_config = SettingsConfigDict(
         env_prefix="DOCLING_MCP_LI_",
         env_file=".env",
         # extra="allow",
     )
-    api_base: str = "http://127.0.0.1:1234/v1"
-    api_key: str = "none"
-    model_id: str = "ibm/granite-3.2-8b"
-    embedding_model: str = "BAAI/bge-base-en-v1.5"
+    api_base: Annotated[
+        str,
+        Field(description="Base URL of the OpenAI-compatible inference endpoint."),
+    ] = "http://127.0.0.1:1234/v1"
+    api_key: Annotated[
+        str, Field(description="API key for the inference endpoint.")
+    ] = "none"
+    model_id: Annotated[
+        str, Field(description="Model identifier for the LLM used in RAG queries.")
+    ] = "ibm/granite-3.2-8b"
+    embedding_model: Annotated[
+        str,
+        Field(description="HuggingFace embedding model name for vector indexing."),
+    ] = "BAAI/bge-base-en-v1.5"
 
 
 settings = Settings()

--- a/docling_mcp/settings/llama_stack.py
+++ b/docling_mcp/settings/llama_stack.py
@@ -1,19 +1,36 @@
 """This module contains the settings for the Llama Stack usages."""
 
+from typing import Annotated
+
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """Settings for the Llama Stack usages."""
+    """Settings for Llama Stack tool integrations.
+
+    All settings are read from environment variables with the
+    `DOCLING_MCP_LLS_` prefix (or from a `.env` file).
+    """
 
     model_config = SettingsConfigDict(
         env_prefix="DOCLING_MCP_LLS_",
         env_file=".env",
         # extra="allow",
     )
-    url: str = "http://localhost:8321"
-    vdb_embedding: str = "all-MiniLM-L6-v2"
-    extraction_model: str = "openai/gpt-oss-20b"
+    url: Annotated[str, Field(description="Base URL of the Llama Stack server.")] = (
+        "http://localhost:8321"
+    )
+    vdb_embedding: Annotated[
+        str,
+        Field(description="Embedding model name used for vector-database ingestion."),
+    ] = "all-MiniLM-L6-v2"
+    extraction_model: Annotated[
+        str,
+        Field(
+            description="Model identifier used for structured information extraction."
+        ),
+    ] = "openai/gpt-oss-20b"
 
 
 settings = Settings()

--- a/docling_mcp/tools/conversion.py
+++ b/docling_mcp/tools/conversion.py
@@ -7,8 +7,7 @@ from pathlib import Path
 from typing import Annotated
 
 from mcp.server.mcpserver import Context
-from mcp.shared.exceptions import MCPError
-from mcp.types import INTERNAL_ERROR, ToolAnnotations
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from docling_mcp.logger import setup_logger
@@ -83,18 +82,13 @@ def convert_document_into_docling_document(
     was already in the local cache, the conversion is skipped and the output
     boolean is set to True.
     """
-    try:
-        converter = get_converter()
-        result = converter.convert_document(source)
+    converter = get_converter()
+    result = converter.convert_document(source)
 
-        # Clean up memory after conversion
-        cleanup_memory()
+    # Clean up memory after conversion
+    cleanup_memory()
 
-        return result
-
-    except Exception as e:
-        logger.exception(f"Error converting document: {source}")
-        raise MCPError(INTERNAL_ERROR, f"Unexpected error: {e!s}") from e
+    return result
 
 
 @mcp.tool(
@@ -118,37 +112,32 @@ async def convert_directory_files_into_docling_document(
     If a document was already in the local cache, the conversion is skipped and the
     output boolean is set to True.
     """
-    try:
-        # Remove any quotes from the source string
-        source = source.strip("\"'")
-        directory = Path(source)
-        files: list[Path] = await asyncio.to_thread(
-            lambda: [f for f in directory.iterdir() if f.is_file()]
-        )
-        out: list[ConversionOutput] = []
+    # Remove any quotes from the source string
+    source = source.strip("\"'")
+    directory = Path(source)
+    files: list[Path] = await asyncio.to_thread(
+        lambda: [f for f in directory.iterdir() if f.is_file()]
+    )
+    out: list[ConversionOutput] = []
 
-        logger.info(f"Converting {len(files)} files from directory: {source}")
-        converter = get_converter()
+    logger.info(f"Converting {len(files)} files from directory: {source}")
+    converter = get_converter()
 
-        for i, file in enumerate(files):
-            logger.info(f"Processing file {file}")
-            await ctx.report_progress(i + 1, len(files))
+    for i, file in enumerate(files):
+        logger.info(f"Processing file {file}")
+        await ctx.report_progress(i + 1, len(files))
 
-            try:
-                result = converter.convert_document(str(file))
-                out.append(result)
-                logger.debug(
-                    f"Completed step {i + 1} with Docling document key: {result.document_key}"
-                )
-            except Exception as e:
-                logger.error(f"Failed to convert {file}: {e}")
-                # Continue with other files
-                continue
+        try:
+            result = converter.convert_document(str(file))
+            out.append(result)
+            logger.debug(
+                f"Completed step {i + 1} with Docling document key: {result.document_key}"
+            )
+        except Exception as e:
+            logger.error(f"Failed to convert {file}: {e}")
+            # Continue with other files
+            continue
 
-        cleanup_memory()
+    cleanup_memory()
 
-        return out
-
-    except Exception as e:
-        logger.exception(f"Error converting files in directory: {source}")
-        raise MCPError(INTERNAL_ERROR, f"Unexpected error: {e!s}") from e
+    return out

--- a/docling_mcp/tools/converters/base.py
+++ b/docling_mcp/tools/converters/base.py
@@ -1,28 +1,56 @@
 """Base classes and protocols for document converters."""
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Annotated, Protocol
+
+from pydantic import Field
 
 
 @dataclass
 class ConversionOutput:
     """Output of document conversion."""
 
-    from_cache: bool
-    document_key: str
+    from_cache: Annotated[
+        bool,
+        Field(description="Whether the document was served from the local cache."),
+    ]
+    document_key: Annotated[
+        str,
+        Field(description="The unique identifier of the document in the local cache."),
+    ]
 
 
 class DocumentConverterProtocol(Protocol):
     """Protocol for document converters."""
 
     def convert_document(self, source: str) -> ConversionOutput:
-        """Convert a single document."""
+        """Convert a single document from a URL or local path.
+
+        Args:
+            source: A local file path, URL, or object-storage URI.
+
+        Returns:
+            A `ConversionOutput` with the cache key and a flag indicating
+            whether the result was served from cache.
+        """
         ...
 
     def convert_directory(self, source: str) -> list[ConversionOutput]:
-        """Convert all files in a directory."""
+        """Convert all files found directly inside a local directory.
+
+        Args:
+            source: Path to a local directory.
+
+        Returns:
+            A list of `ConversionOutput` instances, one per successfully
+            converted file.
+        """
         ...
 
     def is_available(self) -> bool:
-        """Check if this converter is available."""
+        """Check whether this converter is ready to accept conversions.
+
+        Returns:
+            `True` if the converter can process documents, `False` otherwise.
+        """
         ...

--- a/docling_mcp/tools/converters/factory.py
+++ b/docling_mcp/tools/converters/factory.py
@@ -15,7 +15,23 @@ logger = setup_logger()
 
 
 def get_converter() -> RemoteDocumentConverter | LocalDocumentConverter:
-    """Get the appropriate converter based on settings."""
+    """Return the appropriate converter based on the current settings.
+
+    Reads `DOCLING_MCP_CONVERSION_MODE` and, when fallback is enabled,
+    transparently returns a `LocalDocumentConverter` if the remote service
+    is unreachable or misconfigured.
+
+    Returns:
+        A `RemoteDocumentConverter` or `LocalDocumentConverter` instance.
+
+    Raises:
+        ValueError: When the conversion mode is set to `remote` but
+            `DOCLING_MCP_SERVICE_URL` is not configured and fallback is
+            disabled.
+        ImportError: When local conversion is required (either directly or as
+            a fallback) but the `docling-mcp[local]` extra is not installed.
+        ValueError: When an unrecognised conversion mode is encountered.
+    """
     # Import converters lazily to avoid importing DocumentConverter when not needed
     from .remote import RemoteDocumentConverter
 

--- a/docling_mcp/tools/generation.py
+++ b/docling_mcp/tools/generation.py
@@ -110,7 +110,7 @@ def export_docling_document_to_markdown(
         )
 
     markdown = local_document_cache[document_key].export_to_markdown()
-    if max_size:
+    if max_size is not None:
         markdown = markdown[:max_size]
 
     return ExportDocumentMarkdownOutput(document_key, markdown)
@@ -184,7 +184,7 @@ def page_thumbnail(
 ) -> MCPImage:
     """Generate a thumbnail image for the requested page.
 
-    This tool takes a document that exists in the local cache and generates a thumnail image for the requested page.
+    This tool takes a document that exists in the local cache and generates a thumbnail image for the requested page.
     """
     if document_key not in local_document_cache:
         doc_keys = ", ".join(local_document_cache.keys())
@@ -564,12 +564,12 @@ def add_table_in_html_format_to_docling_document(
     ):
         table = doc.add_table(data=conv_result.document.tables[0].data)
 
-        for _ in table_captions or []:
-            caption = doc.add_text(label=DocItemLabel.CAPTION, text=_)
+        for caption_text in table_captions or []:
+            caption = doc.add_text(label=DocItemLabel.CAPTION, text=caption_text)
             table.captions.append(caption.get_ref())
 
-        for _ in table_footnotes or []:
-            footnote = doc.add_text(label=DocItemLabel.FOOTNOTE, text=_)
+        for footnote_text in table_footnotes or []:
+            footnote = doc.add_text(label=DocItemLabel.FOOTNOTE, text=footnote_text)
             table.footnotes.append(footnote.get_ref())
     else:
         raise ValueError(

--- a/docling_mcp/tools/llama_index/milvus_rag.py
+++ b/docling_mcp/tools/llama_index/milvus_rag.py
@@ -9,8 +9,7 @@ from llama_index.core.base.response.schema import (
     RESPONSE_TYPE,
     Response,
 )
-from mcp.shared.exceptions import MCPError
-from mcp.types import INTERNAL_ERROR, ToolAnnotations
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from docling_core.types.doc.document import DoclingDocument
@@ -116,13 +115,5 @@ def search_documents(
     if isinstance(response, Response):
         if response.response is not None:
             return SearchDocumentOutput(answer=response.response)
-        else:
-            raise MCPError(
-                INTERNAL_ERROR,
-                "Response object has no response content",
-            )
-    else:
-        raise MCPError(
-            INTERNAL_ERROR,
-            f"Unexpected response type: {type(response)}",
-        )
+        raise RuntimeError("Response object has no response content")
+    raise RuntimeError(f"Unexpected response type: {type(response)}")

--- a/docling_mcp/tools/llama_stack/_shared.py
+++ b/docling_mcp/tools/llama_stack/_shared.py
@@ -9,6 +9,14 @@ from docling_mcp.settings.llama_stack import settings
 
 @lru_cache
 def get_llama_stack_client() -> LlamaStackClient:
+    """Return a cached `LlamaStackClient` connected to the configured URL.
+
+    The client is constructed once and reused across calls. The base URL is
+    read from `docling_mcp.settings.llama_stack.settings`.
+
+    Returns:
+        A `LlamaStackClient` instance.
+    """
     client = LlamaStackClient(
         base_url=settings.url,
     )

--- a/docling_mcp/tools/manipulation.py
+++ b/docling_mcp/tools/manipulation.py
@@ -344,8 +344,8 @@ def delete_document_items_at_anchors(
     doc = local_document_cache[document_key]
 
     items = []
-    for _ in document_anchors:
-        ref = RefItem(cref=_)
+    for anchor in document_anchors:
+        ref = RefItem(cref=anchor)
         items.append(ref.resolve(doc=doc))
 
     doc.delete_items(node_items=items)

--- a/tests/test_document_manipulation.py
+++ b/tests/test_document_manipulation.py
@@ -1,32 +1,27 @@
 import json
-import os
 from pathlib import Path
 
 import pytest
 
 from docling_core.types.doc.document import DoclingDocument
 
-from docling_mcp.logger import setup_logger
 from docling_mcp.shared import local_document_cache
 from docling_mcp.tools.manipulation import (
     TextSearchOutput,
     search_for_text_in_document_anchors,
 )
 
-logger = setup_logger()
-
 
 def test_search_for_text_in_document_anchors() -> None:
-    # Get the golden search results
     source_path = Path("./tests/data/gt_search_results.json")
 
-    golden_results = {}
+    if not source_path.exists():
+        pytest.skip(
+            "Golden file missing — run once to generate it, then commit the result."
+        )
 
-    if os.path.exists(source_path):
-        with open(source_path) as f:
-            golden_results = json.load(f)
-
-    GENERATE = True if not golden_results else False
+    with open(source_path) as f:
+        golden_results = json.load(f)
 
     # Load two documents into the local cache to search across
     file_path = Path("./tests/data/amt_handbook_sample.json")
@@ -40,72 +35,43 @@ def test_search_for_text_in_document_anchors() -> None:
     local_document_cache[doc_2_key] = doc
 
     # Test exact match searches
-
     doc_1_result = search_for_text_in_document_anchors(
         document_key=doc_1_key, text="load-carrying nut"
     )
-
     doc_2_result = search_for_text_in_document_anchors(
         document_key=doc_2_key, text="pellentesque vulputate"
     )
-
     assert isinstance(doc_1_result, TextSearchOutput)
     assert isinstance(doc_2_result, TextSearchOutput)
-
-    if GENERATE:
-        golden_results["exact_match"] = (doc_1_result.result, doc_2_result.result)
-    else:
-        assert doc_1_result.result == golden_results["exact_match"][0]
-        assert doc_2_result.result == golden_results["exact_match"][1]
+    assert doc_1_result.result == golden_results["exact_match"][0]
+    assert doc_2_result.result == golden_results["exact_match"][1]
 
     # Test keyword match searches
-
     doc_1_result = search_for_text_in_document_anchors(
         document_key=doc_1_key, text="locking section spring mechanism"
     )
-
     doc_2_result = search_for_text_in_document_anchors(
         document_key=doc_2_key, text="porttitor varius"
     )
-
     assert isinstance(doc_1_result, TextSearchOutput)
     assert isinstance(doc_2_result, TextSearchOutput)
-
-    if GENERATE:
-        golden_results["keywords_match"] = (doc_1_result.result, doc_2_result.result)
-    else:
-        assert doc_1_result.result == golden_results["keywords_match"][0]
-        assert doc_2_result.result == golden_results["keywords_match"][1]
+    assert doc_1_result.result == golden_results["keywords_match"][0]
+    assert doc_2_result.result == golden_results["keywords_match"][1]
 
     # Test no match searches
-
     doc_1_result = search_for_text_in_document_anchors(
         document_key=doc_1_key, text="Banana Peel"
     )
-
     doc_2_result = search_for_text_in_document_anchors(
         document_key=doc_2_key, text="Banana Peel"
     )
-
     assert isinstance(doc_1_result, TextSearchOutput)
     assert isinstance(doc_2_result, TextSearchOutput)
-
-    if GENERATE:
-        golden_results["no_match"] = (doc_1_result.result, doc_2_result.result)
-    else:
-        assert doc_1_result.result == golden_results["no_match"][0]
-        assert doc_2_result.result == golden_results["no_match"][1]
+    assert doc_1_result.result == golden_results["no_match"][0]
+    assert doc_2_result.result == golden_results["no_match"][1]
 
     # Test doc key not found
-
     with pytest.raises(ValueError):
         search_for_text_in_document_anchors(
             document_key="banana_peel", text="load-carrying nut"
         )
-
-    # Save the golden results if generated
-
-    if GENERATE:
-        with open(source_path, "w") as f:
-            json.dump(golden_results, f, indent=2)
-        logger.info(f"Generated golden search results at {source_path}")

--- a/tests/test_local_converter.py
+++ b/tests/test_local_converter.py
@@ -83,13 +83,12 @@ class TestLocalDocumentConverter:
         converter = LocalDocumentConverter()
         assert converter.is_available() is True
 
-    @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", False)
+    @patch("docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", True)
     def test_is_available_when_not_installed(self) -> None:
-        """Test is_available returns False when local extra is not installed."""
-        # Can't create converter without LOCAL_CONVERSION_AVAILABLE
-        # So we test the module-level constant directly
-        from docling_mcp.tools import converters
+        """Test is_available returns False when the module flag is patched off post-init."""
+        converter = LocalDocumentConverter()
 
-        with patch.object(converters.local, "LOCAL_CONVERSION_AVAILABLE", False):
-            # Verify the constant is False
-            assert converters.local.LOCAL_CONVERSION_AVAILABLE is False
+        with patch(
+            "docling_mcp.tools.converters.local.LOCAL_CONVERSION_AVAILABLE", False
+        ):
+            assert converter.is_available() is False


### PR DESCRIPTION
## Summary

A focused quality pass covering bug fixes, MCP error-handling alignment, docstring completeness, type-annotation consistency, and test correctness.
No behavior changes to the conversion pipeline or the MCP tool API surface.

## Changes

### Bug fixes

| File | Issue | Fix |
|------|-------|-----|
| `tools/generation.py` | `if max_size:` skips truncation when `max_size=0` | Changed to `if max_size is not None:` |
| `docling_cache.py` | Variable `hash` shadowed the built-in `hash()` | Renamed to `cache_hash` |
| `tools/generation.py`, `tools/manipulation.py` | Loop variable `_` used as a value (`for _ in ...: f(_)`) | Renamed to `caption_text`, `footnote_text`, `anchor` |

### MCP error-handling alignment

`convert_document_into_docling_document`, `convert_directory_files_into_docling_document`, and `search_documents` wrapped all exceptions in `MCPError(INTERNAL_ERROR, ...)`. Per the [MCP SDK error-handling docs](https://py.sdk.modelcontextprotocol.io/servers/handling-errors/):

> *Raise any exception for a failure of execution … Raise MCPError when
> the request itself should be rejected.*

The SDK's `_handle_call_tool` already catches any plain `Exception` and converts it into a `CallToolResult(is_error=True)` response the model can read and recover from. Wrapping in `MCPError` instead produces an unrecoverable JSON-RPC protocol error that gives the model nothing to read. The wrappers are removed; domain errors now surface naturally.

### Docstrings

All new and updated docstrings follow Google style (single-backtick code references, `Args:` / `Returns:` / `Raises:` sections).

### Type annotations

- `ConversionOutput.from_cache` and `document_key` now use `Annotated[..., Field(description=...)]`, consistent with every other output dataclass in the project.
- All fields in `settings/llama_stack.py` and `settings/llama_index.py` annotated with `Annotated[str, Field(description=...)]`; class docstrings updated to document the env-var prefix.

### Tests

Improved tests `test_is_available_when_not_installed` and `test_search_for_text_in_document_anchors`.