### PR TITLE
fix: pass service timeout and retry settings to the remote client

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ your MCP client config. Copy [`.env.example`](.env.example) as a starting point.
 |---|---|---|
 | `DOCLING_MCP_SERVICE_URL` | — | URL of the Docling Serve instance |
 | `DOCLING_MCP_SERVICE_API_KEY` | — | API key for the service |
-| `DOCLING_MCP_SERVICE_TIMEOUT` | `300.0` | Request timeout in seconds |
+| `DOCLING_MCP_SERVICE_TIMEOUT` | `300.0` | Timeout in seconds for a whole conversion job |
 | `DOCLING_MCP_SERVICE_MAX_RETRIES` | `3` | Max retry attempts |
 | `DOCLING_MCP_FALLBACK_TO_LOCAL` | `false` | Fall back to local if service is unreachable (requires `docling-mcp[local]`) |
 

--- a/docling_mcp/tools/converters/remote.py
+++ b/docling_mcp/tools/converters/remote.py
@@ -44,6 +44,8 @@ class RemoteDocumentConverter:
         self.client = DoclingServiceClient(
             url=settings.service_url,
             api_key=api_key,
+            job_timeout=settings.service_timeout,
+            http_retries=settings.service_max_retries,
         )
         logger.info(f"Initialized remote converter with URL: {settings.service_url}")
 

--- a/tests/test_remote_converter.py
+++ b/tests/test_remote_converter.py
@@ -35,12 +35,37 @@ class TestRemoteDocumentConverter:
         """Test successful initialization with service URL."""
         mock_settings.service_url = "https://test.example.com"
         mock_settings.service_api_key = "test-key"
+        mock_settings.service_timeout = 300.0
+        mock_settings.service_max_retries = 3
 
         converter = RemoteDocumentConverter()
 
         assert converter is not None
         mock_client_class.assert_called_once_with(
-            url="https://test.example.com", api_key="test-key"
+            url="https://test.example.com",
+            api_key="test-key",
+            job_timeout=300.0,
+            http_retries=3,
+        )
+
+    @patch("docling_mcp.tools.converters.remote.DoclingServiceClient")
+    @patch("docling_mcp.tools.converters.remote.settings")
+    def test_init_forwards_timeout_and_retry_settings(
+        self, mock_settings: Any, mock_client_class: Any
+    ) -> None:
+        """Non-default timeout and retry settings reach the service client."""
+        mock_settings.service_url = "https://test.example.com"
+        mock_settings.service_api_key = None
+        mock_settings.service_timeout = 1200.0
+        mock_settings.service_max_retries = 7
+
+        RemoteDocumentConverter()
+
+        mock_client_class.assert_called_once_with(
+            url="https://test.example.com",
+            api_key="",
+            job_timeout=1200.0,
+            http_retries=7,
         )
 
     @patch("docling_mcp.tools.converters.remote.local_document_cache", {})


### PR DESCRIPTION
Fixes #134.

## Cause

`RemoteDocumentConverter.__init__` built `DoclingServiceClient` with only `url` and `api_key`. `settings` was already in scope and already carried `service_timeout` and `service_max_retries`, but neither was passed, so both settings were inert.

`DoclingServiceClient` reads no environment of its own, so its constructor is the only entry point for either value. That made the 300 s job ceiling unreachable by configuration, even though `DOCLING_MCP_SERVICE_TIMEOUT` and `DOCLING_MCP_SERVICE_MAX_RETRIES` are documented in the README, shipped in `.env.example`, and exposed through `mcpb/manifest.json` and `server.json`.

## Change

```diff
 self.client = DoclingServiceClient(
     url=settings.service_url,
     api_key=api_key,
+    job_timeout=settings.service_timeout,
+    http_retries=settings.service_max_retries,
 )
```

**Defaults are unchanged.** They match on both sides, `300.0` and `3`, so nothing moves for anyone who has not set the variables; the settings simply start working for anyone who has.

`http_connect_timeout` and `http_read_timeout` have no counterpart in `ServiceClientSettings` and are left at their defaults, keeping this minimal. Exposing them would be a separate decision.

## Docs

`service_timeout` maps to `job_timeout`, which bounds the whole conversion job rather than one HTTP request, so the README row now reads "Timeout in seconds for a whole conversion job". Happy to drop this hunk if you would rather keep the diff to the one file.

## Tests

`tests/test_remote_converter.py`:

- `test_init_with_service_url_succeeds` sets both settings explicitly and asserts the full constructor call, since the previous `assert_called_once_with` pinned the two-argument shape.
- `test_init_forwards_timeout_and_retry_settings` is new: non-default values (`1200.0` and `7`) must arrive as `job_timeout` and `http_retries`.

Verified locally with `uv sync --group dev`:

- `pytest tests/test_remote_converter.py tests/test_converter_factory.py tests/test_remote_sources.py` — 14 passed, 1 skipped (`fsspec` not installed).
- `ruff check`, `ruff format --check` and `mypy` clean on the touched files.

Three tests in the full run fail in my environment because I did not install the `local` extra. They fail identically on unmodified `main`, so they are unrelated to this change: `test_conversion_tools.py::test_convert_directory_files_into_docling_document`, `test_generation_tools.py::test_table_in_html_format_to_docling_document`, `test_local_converter.py::TestLocalDocumentConverter::test_convert_document_success`.